### PR TITLE
Dependency inject random

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import difflib
 import functools
 import os
 from random import Random
+import random
 import re
 import sys
 import time
@@ -79,12 +80,7 @@ class Permuter:
 
         return (base_source, *self.scorer.score(start_o))
 
-    def _update_seed(self) -> None:
-        rand_seed = self.random.randrange(10**18) + self.iteration
-        self.random.seed(rand_seed)
-
     def permutate_next(self) -> bool:
-        self._update_seed()
         cand_c = next(self.iterator, None)
         if cand_c is None:
             return False
@@ -150,10 +146,10 @@ def wrapped_main(options: Options, heartbeat: Callable[[], None]) -> int:
     print("Loading...")
 
 
-    if options.seed != None:
+    if options.seed is not None:
         start_seed = options.seed
     else:
-        start_seed = randrange(sys.maxsize) # Random seed from default random
+        start_seed = random.randrange(sys.maxsize) # Random seed from default random
 
     name_counts: Dict[str, int] = {}
     permuters: List[Permuter] = []

--- a/main.py
+++ b/main.py
@@ -119,8 +119,6 @@ def write_candidate(perm: Permuter, source: str) -> None:
 
 def main(options: Options) -> int:
     last_time = time.time()
-    if options.seed is None:
-        options.seed = os.urandom(8)
     try:
         def heartbeat() -> None:
             nonlocal last_time
@@ -143,6 +141,7 @@ def wrapped_main(options: Options, heartbeat: Callable[[], None]) -> int:
     print("Loading...")
 
     random = Random()
+    if options.seed != None:
     random.seed(options.seed)
 
     name_counts: Dict[str, int] = {}
@@ -193,11 +192,6 @@ def wrapped_main(options: Options, heartbeat: Callable[[], None]) -> int:
         perm_ind = (perm_ind + 1) % len(permuters)
         perm = permuters[perm_ind]
 
-        if iteration == 0 and options.seed is not None:
-            rand_seed = options.seed
-        else:
-            rand_seed = random.randrange(10**18) + iteration
-        random.seed(rand_seed)
         try:
             t0 = time.time()
             if not perm.permutate_next():

--- a/perm/perm_eval.py
+++ b/perm/perm_eval.py
@@ -1,9 +1,9 @@
 from typing import List, Iterable, Set
-import random
+from random import Random
 
 from perm.perm import Perm, EvalState
 
-def get_all_seeds(total_count: int) -> Iterable[int]:
+def get_all_seeds(total_count: int, random: Random) -> Iterable[int]:
     """Generate all numbers 0..total_count-1 in random order, in expected time
     O(1) per number."""
     seen: Set[int] = set()
@@ -21,9 +21,9 @@ def get_all_seeds(total_count: int) -> Iterable[int]:
     for seed in remaining:
         yield seed
 
-def perm_evaluate_all(perm: Perm) -> Iterable[str]:
+def perm_evaluate_all(perm: Perm, random: Random) -> Iterable[str]:
     while True:
-        for seed in get_all_seeds(perm.perm_count):
+        for seed in get_all_seeds(perm.perm_count, random):
             yield perm.evaluate(seed, EvalState())
         if not perm.is_random():
             break


### PR DESCRIPTION
Use dependency injection for the random object.

This is in preparation for multi-threading so each thread can get its own random class and concurrency issues. 