### PR TITLE
Change split character from , to |

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The permuter expects as input one or more directory containing:
 
 See USAGE.md for more details on how to set these up.
 
-The .c file may be modified with any of the following macros which affect manual permutation. Arguments to the macros are split by `|`:
+The .c file may be modified with any of the following macros which affect manual permutation. Arguments to the macros are split by `|` (when not nested within parenthesis):
 
 - `PERM_GENERAL(a|b|...)` expands to any of `a`, `b`, ...
 - `PERM_TYPECAST(a|b|...)` expands to any of `(a)`, `(b)`, ... (empty argument for no cast at all)

--- a/README.md
+++ b/README.md
@@ -17,19 +17,19 @@ The permuter expects as input one or more directory containing:
 
 See USAGE.md for more details on how to set these up.
 
-The .c file may be modified with any of the following macros which affect manual permutation:
+The .c file may be modified with any of the following macros which affect manual permutation. Arguments to the macros are split by `|`:
 
-- `PERM_GENERAL(a, b, ...)` expands to any of `a`, `b`, ...
-- `PERM_TYPECAST(a, b, ...)` expands to any of `(a)`, `(b)`, ... (empty argument for no cast at all)
-- `PERM_TERNARY(prefix, a, b, c)` expands to either `prefix a ? b : c` or `if (a) prefix b; else prefix c;`.
-- `PERM_VAR(a, b)` sets the meta-variable `a` to `b`, `PERM_VAR(a)` expands to the meta-variable `a`.
+- `PERM_GENERAL(a|b|...)` expands to any of `a`, `b`, ...
+- `PERM_TYPECAST(a|b|...)` expands to any of `(a)`, `(b)`, ... (empty argument for no cast at all)
+- `PERM_TERNARY(prefix|a|b|c)` expands to either `prefix a ? b : c` or `if (a) prefix b; else prefix c;`.
+- `PERM_VAR(a|b)` sets the meta-variable `a` to `b`, `PERM_VAR(a)` expands to the meta-variable `a`.
 - `PERM_RANDOMIZE(code)` expands to `code`, but allows randomization within that region.
 - `PERM_CONDNEZ(cond)` expands to either `cond` or `(cond) != 0`.
 
 Nested macros are allowed, so e.g.
 ```
-PERM_VAR(delayed, )
-PERM_GENERAL(stmt;, PERM_VAR(delayed, stmt;))
+PERM_VAR(delayed|)
+PERM_GENERAL(stmt;|PERM_VAR(delayed|stmt;))
 ...
 PERM_VAR(delayed)
 ```

--- a/perm/perm_gen.py
+++ b/perm/perm_gen.py
@@ -20,7 +20,7 @@ def get_parenthesis_args(s: str) -> Tuple[List[str], str]:
     args = []
     for i, c in enumerate(s):
         # Find individual args
-        if c == ',' and level == 1:
+        if c == '|' and level == 1:
             args.append(current)
             current = ''
         # Track parenthesis level

--- a/test/test_general.c
+++ b/test/test_general.c
@@ -4,7 +4,7 @@ int test_general() {
 }
 #else
 int test_general() {
-    return PERM_GENERAL(32,64);
+    return PERM_GENERAL(32|64);
 }
 #endif
 
@@ -14,7 +14,7 @@ int test_general_3() {
 }
 #else
 int test_general_3() {
-    return PERM_GENERAL(32,48,64);
+    return PERM_GENERAL(32|48|64);
 }
 #endif
 
@@ -24,6 +24,6 @@ int test_general_multiple() {
 }
 #else
 int test_general_multiple() {
-    return PERM_GENERAL(1,2,3) + PERM_GENERAL(4,5,6);
+    return PERM_GENERAL(1|2|3) + PERM_GENERAL(4|5|6);
 } 
 #endif

--- a/test/test_ternary.c
+++ b/test/test_ternary.c
@@ -10,7 +10,7 @@ int test_ternary1(int cond) {
 #else
 int test_ternary1(int cond) {
     int test;
-    PERM_TERNARY(test = ,cond,1,2)
+    PERM_TERNARY(test = |cond|1|2)
     return test;
 }
 #endif
@@ -24,7 +24,7 @@ int test_ternary2(int cond) {
 #else
 int test_ternary2(int cond) {
     int test;
-    PERM_TERNARY(test = ,cond,1,2)
+    PERM_TERNARY(test = |cond|1|2)
     return test;
 }
 #endif

--- a/test/test_type.c
+++ b/test/test_type.c
@@ -1,29 +1,29 @@
 #ifdef ACTUAL
-int test_type1(int a, int b) {
+int test_type1(int a| int b) {
     return a / b;
 }
 #else
-int test_type1(int a, int b) {
-    return a / PERM_TYPECAST(,unsigned int,float) b;
+int test_type1(int a| int b) {
+    return a / PERM_TYPECAST(|unsigned int|float) b;
 }
 #endif
 
 #ifdef ACTUAL
-int test_type2(int a, int b) {
+int test_type2(int a| int b) {
     return a / (unsigned int) b;
 }
 #else
-int test_type2(int a, int b) {
-    return a / PERM_TYPECAST(,unsigned int,float) b;
+int test_type2(int a| int b) {
+    return a / PERM_TYPECAST(|unsigned int|float) b;
 }
 #endif
 
 #ifdef ACTUAL
-int test_type3(int a, int b) {
+int test_type3(int a| int b) {
     return a / (float) b;
 }
 #else
-int test_type3(int a, int b) {
-    return a / PERM_TYPECAST(,unsigned int,float) b;
+int test_type3(int a| int b) {
+    return a / PERM_TYPECAST(|unsigned int|float) b;
 }
 #endif

--- a/test/test_type.c
+++ b/test/test_type.c
@@ -1,29 +1,29 @@
 #ifdef ACTUAL
-int test_type1(int a| int b) {
+int test_type1(int a, int b) {
     return a / b;
 }
 #else
-int test_type1(int a| int b) {
+int test_type1(int a, int b) {
     return a / PERM_TYPECAST(|unsigned int|float) b;
 }
 #endif
 
 #ifdef ACTUAL
-int test_type2(int a| int b) {
+int test_type2(int a, int b) {
     return a / (unsigned int) b;
 }
 #else
-int test_type2(int a| int b) {
+int test_type2(int a, int b) {
     return a / PERM_TYPECAST(|unsigned int|float) b;
 }
 #endif
 
 #ifdef ACTUAL
-int test_type3(int a| int b) {
+int test_type3(int a, int b) {
     return a / (float) b;
 }
 #else
-int test_type3(int a| int b) {
+int test_type3(int a, int b) {
     return a / PERM_TYPECAST(|unsigned int|float) b;
 }
 #endif


### PR DESCRIPTION
This is to better support the PERM_LINESWAP, but more generally other C expressions which use `,`.