### PR TITLE
fix insertion/deletion penalty bug in scorer.py

### DIFF
--- a/src/scorer.py
+++ b/src/scorer.py
@@ -126,14 +126,12 @@ class Scorer:
                 for k in range(j1, j2):
                     diff_delete(self.target_seq[k].line)
 
-        for value in set(insertions):
-            remove_count = min([insertions.count(value), deletions.count(value)])
-            score += remove_count * self.PENALTY_REORDERING
-            for _ in range(remove_count):
-                insertions.remove(value)
-                deletions.remove(value)
-
-        score += len(deletions) * self.PENALTY_DELETION
-        score += len(insertions) * self.PENALTY_INSERTION
+        insertions = Counter(insertions)
+        deletions = Counter(deletions)
+        for item in insertions + deletions:
+          ins = insertions[item]
+          dels = deletions[item]
+          common = min(ins, dels)
+          score += (ins - common) * self.PENALTY_INSERTION + (dels - common) * self.PENALTY_DELETION + self.PENALTY_REORDERING
 
         return (score, hashlib.sha256(objdump_output.encode()).hexdigest())

--- a/src/scorer.py
+++ b/src/scorer.py
@@ -4,6 +4,8 @@ import hashlib
 import re
 import subprocess
 from typing import Tuple, List, Optional
+from collections import Counter
+
 
 from .objdump import objdump, sp_offset
 
@@ -132,6 +134,6 @@ class Scorer:
           ins = insertions[item]
           dels = deletions[item]
           common = min(ins, dels)
-          score += (ins - common) * self.PENALTY_INSERTION + (dels - common) * self.PENALTY_DELETION + self.PENALTY_REORDERING
+          score += (ins - common) * self.PENALTY_INSERTION + (dels - common) * self.PENALTY_DELETION + self.PENALTY_REORDERING * common
 
         return (score, hashlib.sha256(objdump_output.encode()).hexdigest())

--- a/src/scorer.py
+++ b/src/scorer.py
@@ -126,12 +126,14 @@ class Scorer:
                 for k in range(j1, j2):
                     diff_delete(self.target_seq[k].line)
 
-        common = set(deletions) & set(insertions)
-        score += len(common) * self.PENALTY_REORDERING
-        for change in deletions:
-            if change not in common:
-                score += self.PENALTY_DELETION
-        for change in insertions:
-            if change not in common:
-                score += self.PENALTY_INSERTION
+        for value in set(insertions):
+            remove_count = min([insertions.count(value), deletions.count(value)])
+            score += remove_count * self.PENALTY_REORDERING
+            for _ in range(remove_count):
+                insertions.remove(value)
+                deletions.remove(value)
+
+        score += len(deletions) * self.PENALTY_DELETION
+        score += len(insertions) * self.PENALTY_INSERTION
+
         return (score, hashlib.sha256(objdump_output.encode()).hexdigest())


### PR DESCRIPTION
The original scoring used a set to record any commonalities between the insertion and deletion lists, when considering the reordering penalty. Later, when checking to see if an insertion or deletion was considered a reordering, it (erroneously) checked if the opcode from the common set was in the list of insertions or deletions. This fails to take into account the case where two of the same opcode was inserted or deleted, but only one should be considered a case of reordering. The new code removes only the number of occurrences common between the two lists; e.g. if insertions has 5 and deletions has 4, 4 of the item is removed from both insertions and deletions.
In order to account for reorderings, num_common*PENALTY_REORDERING is added to the score. This correctly accounts for non-reorderings of the exact same opcode, as well as multiple reorderings of the same opcode.