### PR TITLE
add compiler_command/assembler_command settings

### DIFF
--- a/import.py
+++ b/import.py
@@ -564,13 +564,24 @@ def main() -> None:
             break
 
     build_system = settings.get("build_system", "make")
-    assert isinstance(build_system, str)
+    compiler = settings.get("compiler_command")
+    assembler = settings.get("assembler_command")
     make_flags = args.make_flags
 
     func_name, asm_cont = parse_asm(args.asm_file)
     print(f"Function name: {func_name}")
 
-    compiler, assembler = find_build_command_line(root_dir, args.c_file, make_flags, build_system)
+    if compiler or assembler:
+        assert isinstance(compiler, str)
+        assert isinstance(assembler, str)
+        assert settings.get("build_system") is None
+
+        compiler = shlex.split(compiler)
+        assembler = shlex.split(assembler)
+    else:
+        assert isinstance(build_system, str)
+        compiler, assembler = find_build_command_line(root_dir, args.c_file, make_flags, build_system)
+
     print(f"Compiler: {formatcmd(compiler)} {{input}} -o {{output}}")
     print(f"Assembler: {formatcmd(assembler)} {{input}} -o {{output}}")
 


### PR DESCRIPTION
Adds two new `permuter_settings.toml` options for skipping the 'figure out the compile command via Make/Ninja' process.

e.g. on https://github.com/pmret/papermario:
```toml
compiler_command = "cpp -Iinclude -Isrc -D _LANGUAGE_C -D _FINALROM -ffreestanding -DF3DEX_GBI_2 -D_MIPS_SZLONG=32  -D SCRIPT(...)={} | iconv --from UTF-8 --to SHIFT-JIS | tools/linux/cc1 -O2 -quiet -G 0 -mcpu=vr4300 -mfix4300 -mips3 -mgp32 -mfp32 -Wuninitialized -Wshadow  -o - | tools/linux/mips-nintendo-nu64-as -EB -G 0 -"
assembler_command = "mips-linux-gnu-as -march=vr4300 -mabi=32"
```