### PR TITLE
default to selecting the last function in file when there is more than one

### DIFF
--- a/src/permuter.py
+++ b/src/permuter.py
@@ -100,12 +100,8 @@ class Permuter:
             fns = _find_fns(source)
             if len(fns) == 0:
                 raise Exception(f"{self.source_file} does not contain any function!")
-            if len(fns) > 1:
-                raise Exception(
-                    f"{self.source_file} must contain only one function, "
-                    "or have a function.txt next to it with a function name."
-                )
-            self.fn_name = fns[0]
+            self.fn_name = fns[-1]
+            print("selecting function: ", self.fn_name)
         else:
             self.fn_name = fn_name
         self.unique_name = self.fn_name

--- a/src/permuter.py
+++ b/src/permuter.py
@@ -101,7 +101,7 @@ class Permuter:
             if len(fns) == 0:
                 raise Exception(f"{self.source_file} does not contain any function!")
             self.fn_name = fns[-1]
-            print("selecting function: ", self.fn_name)
+            print("Selecting function: ", self.fn_name)
         else:
             self.fn_name = fn_name
         self.unique_name = self.fn_name


### PR DESCRIPTION
Please consider this PR.

A common workflow with mwcc ppc projects is having a very large context that is copied across scratches that often times has several inlines and nested inlines, these count as functions making therefore more than one function in the file, and the function name must be specified function.txt, but that is another step which makes slows down work flow.  Adding this PR would save time and make it easier to use by just defaulting to the last function in the file.  (since inlines are typically above in context)

So with this PR, you can still specify a function with that txt file, but in the case where its not specified and there are more than one function, it will just default to choosing the last (bottom) function.