### PR TITLE
trim source output to only show the target function code and below

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -103,9 +103,12 @@ def write_candidate(perm: Permuter, result: CandidateResult) -> None:
         except FileExistsError:
             pass
     source = result.source
+
+    fn_str_index = source.find(perm.fn_name)
+
     assert source is not None, "Permuter._need_to_send_source is wrong!"
     with open(os.path.join(output_dir, "source.c"), "x", encoding="utf-8") as f:
-        f.write(source)
+        f.write(source[fn_str_index:])
     with open(os.path.join(output_dir, "score.txt"), "x", encoding="utf-8") as f:
         f.write(f"{result.score}\n")
     with open(os.path.join(output_dir, "diff.txt"), "x", encoding="utf-8") as f:
@@ -172,7 +175,6 @@ def post_score(
             color = "\u001b[33m"
             msg = f"found different asm with same score ({score_value})"
         context.printer.print(msg, permuter, who, color=color)
-
         write_candidate(permuter, result)
     if not context.options.quiet:
         context.printer.progress(status_line)

--- a/src/main.py
+++ b/src/main.py
@@ -92,7 +92,7 @@ class EvalContext:
     permuters: List[Permuter] = field(default_factory=list)
 
 
-def trim_source(source, fn_name):
+def trim_source(source: str, fn_name: str) -> str:
     fn_index = source.find(fn_name)
     if fn_index != -1:
         new_index = source.rfind("\n", 0, fn_index)

--- a/src/main.py
+++ b/src/main.py
@@ -110,7 +110,12 @@ def write_candidate(perm: Permuter, result: CandidateResult, no_context_output: 
     with open(os.path.join(output_dir, "source.c"), "x", encoding="utf-8") as f:
         if no_context_output:
             fn_str_index = source.find(perm.fn_name)
+            for i in range(fn_str_index-30, fn_str_index-1):
+                if (source[i] == '\n' or source[i] == '\r'):
+                    fn_str_index = i
+                    break
             f.write(source[fn_str_index:])
+
         else:
             f.write(source)
     with open(os.path.join(output_dir, "score.txt"), "x", encoding="utf-8") as f:


### PR DESCRIPTION
Often times context is thousands of lines long (atleast for decomp projects I am involved in) and it is a pain to scroll down all the time to view the function of interest at the bottom, and also lots of unnecessary disk usage.

This simply finds the first instance of the function name and then only saves text after that point.