### PR TITLE
tweak to prunt_ast

### DIFF
--- a/src/ast_util.py
+++ b/src/ast_util.py
@@ -387,6 +387,8 @@ def prune_ast(fn: ca.FuncDef, ast: ca.FileAST) -> int:
             add_type_edges(item.type, i)
         elif isinstance(item, ca.Pragma) and "GLOBAL_ASM" in item.string:
             pass
+        elif item is not fn and isinstance(item, ca.FuncDef):
+            edges[item.decl.name].append(i)
         else:
             gc_roots.append(i)
 


### PR DESCRIPTION
tweak to prunt_ast: so it strips out inline functions defs that are not used by target function, but keeps ones that are used