### PR TITLE
Randomization pass: Flatten fields out of a substruct

### DIFF
--- a/default_weights.toml
+++ b/default_weights.toml
@@ -33,6 +33,8 @@ perm_chain_assignment = 5
 perm_long_chain_assignment = 3
 perm_pad_var_decl = 1
 perm_inline = 10
+perm_inline_get_structmember = 1
+perm_flatten_struct = 5
 
 [ido]
 perm_float_literal = 10

--- a/default_weights.toml
+++ b/default_weights.toml
@@ -33,7 +33,6 @@ perm_chain_assignment = 5
 perm_long_chain_assignment = 3
 perm_pad_var_decl = 1
 perm_inline = 10
-perm_inline_get_structmember = 1
 perm_flatten_struct = 5
 
 [ido]

--- a/src/ast_types.py
+++ b/src/ast_types.py
@@ -199,7 +199,6 @@ def decayed_expr_type(expr: ca.Node, typemap: TypeMap) -> SimpleType:
 def resolve_struct_def(struct: ca.TypeDecl, typemap: TypeMap) -> Optional[ca.Struct]:
     """Resolve struct definition for a given type.
     """
-    # print('resolve structdef of:', struct)
     if isinstance(struct.type, ca.IdentifierType):
         idType = struct.type.names[0]
         if idType in typemap.typedefs:

--- a/src/ast_types.py
+++ b/src/ast_types.py
@@ -8,7 +8,7 @@ They make a number of simplifying assumptions:
 For the purposes of the randomizer these restrictions are acceptable."""
 
 from dataclasses import dataclass, field
-from typing import Union, Dict, Set, List
+from typing import Union, Dict, Set, List, Optional
 
 from pycparser import c_ast as ca
 
@@ -195,6 +195,21 @@ def expr_type(node: ca.Node, typemap: TypeMap) -> Type:
 def decayed_expr_type(expr: ca.Node, typemap: TypeMap) -> SimpleType:
     return pointer_decay(expr_type(expr, typemap), typemap)
 
+
+def resolve_struct_def(struct: ca.TypeDecl, typemap: TypeMap) -> Optional[ca.Struct]:
+    """Resolve struct definition for a given type.
+    """
+    # print('resolve structdef of:', struct)
+    if isinstance(struct.type, ca.IdentifierType):
+        idType = struct.type.names[0]
+        if idType in typemap.typedefs:
+            return resolve_struct_def(typemap.typedefs[idType], typemap)
+        return None
+    if struct.type.decls is not None:
+        return struct.type
+    if struct.type.name in typemap.struct_defs:
+        return typemap.struct_defs[struct.type.name]
+    return None
 
 def same_type(
     type1: Type, type2: Type, typemap: TypeMap, allow_similar: bool = False

--- a/src/ast_util.py
+++ b/src/ast_util.py
@@ -202,10 +202,9 @@ def struct_field_idx(struct: ca.Struct, field_name: str) -> int:
 
 
 def struct_substruct_idx(parent: ca.Struct, substruct: ca.Struct, typemap: TypeMap) -> int:
-    print('parent:')
     parent.show()
     for i, decl in enumerate(parent.decls):
-        if isinstance(decl.type, ca.TypeDecl): # and same_type(decl.type.type, substruct, typemap):
+        if isinstance(decl.type, ca.TypeDecl):
             decl_struct = resolve_struct_def(decl.type, typemap)
             if decl_struct is substruct:
                 return i
@@ -349,18 +348,10 @@ def flatten_fields(parent: ca.Struct, parent_field: str, substruct: ca.Struct, s
     Returns a mapping from the original names of the moved fields to their
     (potentially) new names in the parent.
     """
-    # print('parent:')
-    # parent.show()
-    # print('substruct:')
-    # substruct.show()
-
     parent_field_names = set([decl.name for decl in parent.decls])
 
     parent_idx = struct_field_idx(parent, parent_field)
     shift_idx = struct_field_idx(substruct, substruct_field)
-    print('parent_idx:', parent_idx)
-    print('shift_idx:', shift_idx)
-    print('flatten upwards', flatten_upwards)
     if flatten_upwards:
         moved_fields = move_fields(substruct, parent, 0, shift_idx + 1, parent_idx)
         substruct_i = parent_idx + shift_idx + 1
@@ -370,14 +361,8 @@ def flatten_fields(parent: ca.Struct, parent_field: str, substruct: ca.Struct, s
 
     # If substruct is empty, remove it from the parent
     if not substruct.decls:
-        print('gloom')
         struct_remove_field_i(parent, substruct_i)
         parent_field_names.remove(parent_field)
-
-    print('newParent:')
-    parent.show()
-    print('newSubstruct:')
-    substruct.show()
 
     return deduplicate_struct_field_names(moved_fields, parent_field_names)
 

--- a/src/permuter.py
+++ b/src/permuter.py
@@ -193,8 +193,6 @@ class Permuter:
                 rng_seed=rng_seed,
             )
 
-        print('mesprit -- randomization pass')
-        print('candidate seed:', self._cur_cand.rng_seed)
         # Randomize the candidate, until we find a source we haven't seen before
         if self._permutations.is_random():
             while True:

--- a/src/permuter.py
+++ b/src/permuter.py
@@ -193,6 +193,8 @@ class Permuter:
                 rng_seed=rng_seed,
             )
 
+        print('mesprit -- randomization pass')
+        print('candidate seed:', self._cur_cand.rng_seed)
         # Randomize the candidate, until we find a source we haven't seen before
         if self._permutations.is_random():
             while True:

--- a/src/randomizer.py
+++ b/src/randomizer.py
@@ -1,4 +1,5 @@
 import bisect
+from collections import defaultdict
 import copy
 import sys
 from dataclasses import dataclass, field
@@ -32,6 +33,7 @@ from .ast_types import (
     decayed_expr_type,
     get_decl_type,
     resolve_typedefs,
+    resolve_struct_def,
     same_type,
     set_decl_name,
     pointer_decay,
@@ -79,6 +81,10 @@ PROB_KEEP_REPLACED_VAR = 0.2
 
 # Change the return type of an external function to void with this probability.
 PROB_RET_VOID = 0.2
+
+# When flattening fields from a substruct, flatten the fields upwards with this
+# probability.
+PROB_FLATTEN_UPWARDS = 0.5
 
 # Number larger than any node index. (If you're trying to compile a 1 GB large
 # C file to matching asm, you have bigger problems than this limit.)
@@ -500,24 +506,6 @@ def get_insertion_points(
     if not allow_within_decl:
         cands = [c for c in cands if not isinstance(c[3], ca.Decl)]
     return cands
-
-
-def get_noncolliding_name(ast: ca.FileAST, name: str) -> str:
-    used_names: Set[str] = set()
-
-    for item in ast.ext:
-        if isinstance(item, ca.Decl) and item.name:
-            used_names.add(item.name)
-        if isinstance(item, ca.FuncDef) and item.decl.name:
-            used_names.add(item.decl.name)
-
-    new_name = name
-    counter = 1
-    while new_name in used_names:
-        counter += 1
-        new_name = f"{new_name}{counter}"
-
-    return new_name
 
 
 def maybe_reuse_var(
@@ -2244,7 +2232,7 @@ def perm_inline(
     chosen_cand = random_weighted(random, cands)
 
     ret_type = decayed_expr_type(chosen_cand, typemap)
-    new_fn_name = get_noncolliding_name(ast, "inline_fn")
+    new_fn_name = ast_util.get_noncolliding_fn_name(ast, "inline_fn")
 
     cut_prob = random.uniform(0, 1) * random.uniform(0, 1)
     cut_expr, cut_types = cut_ast(chosen_cand, cut_prob, typemap, random)
@@ -2298,40 +2286,174 @@ def perm_inline(
     ast.ext.insert(ast.ext.index(fn), fn_def)
 
 
+# A map of all the parents this substruct is referenced from to the list of
+# references via that parent.
+ParentRefs = Dict[ca.Struct, List[ca.StructRef]]
+
+### How to commit struct changes
+    # Two parts:
+    #  1) Commit change to struct definition
+    #  2) Commit change to any struct references (not restricted by region,
+    #     since we want the file to compile)
+    #
+    # Notes:
+    #  - We don't need to modify the AST of the whole struct, just the parent
+    #    and substruct.
+
+# How to add this: We'll probably need to collect all the struct references
+# within the given region. Then we'll have to modify the struct and re-commit it
+# (somehow?)
+def perm_flatten_struct(
+    fn: ca.FuncDef, ast: ca.FileAST, indices: Indices, region: Region, random: Random
+) -> None:
+    """Moves fields from a nested struct into its parent struct. Only types used
+    within the given region are affected."""
+    # Steps:
+    #  1. Get all leaf fields referenced from the region. Make sure to only pull
+    #     leaf fields in a substruct (??).
+    #  2. Select a leaf field at random.
+    #  3. Toss coin to flatten upwards or downwards.
+    #  4. Pick a random `endpoint` within the substruct.
+    #  5. Shift subset of fields upwards or downwards into parent struct.
+    #     `shift_fields(parent_struct: Node, substruct: Node, field_idx: int, shift_up: bool)` # todo: should be more specific than Node
+    # ??  How do I commit struct changes and change all other references to
+    #     shifted fields?
+    #
+    # No topological sort required for struct definitions with flatten. Will
+    # need to do this for FOLD.
+
+    # TODO: With a get_mutable_node(node: Node) function, you could instead
+    # just get a mutable copy of the parent struct once it is selected.
+    ast_util.deepcopy_struct_defs(ast)
+    typemap = build_typemap(ast, fn)
+    substructs: Dict[ca.Struct, ParentRefs] = defaultdict(lambda: defaultdict(list))
+    fields: Set[ca.StructRef] = set()
+
+    class StructRefVisitor(ca.NodeVisitor):
+        def visit_StructRef(self, node: ca.StructRef) -> None:
+            if region.contains_node(node) and ast_util.count_chained_structrefs(node) >= 1:
+                # TODO: Consider merging decayed_expr_type() into resolve_struct_def()
+                substruct = resolve_struct_def(decayed_expr_type(node.name, typemap), typemap)
+                parent = resolve_struct_def(decayed_expr_type(node.name.name, typemap), typemap)
+                substructs[substruct][parent].append(node)
+
+    # Get all leaf fields in the region that are within a substruct. The fields
+    # must be accessed from a parent struct.
+    StructRefVisitor().visit(fn)
+    print('barboach')
+    # print('Length structrefs:', len(fields))
+    # print(fields)
+
+    # print('substructs:')
+    # print(substructs)
+    print('Length of substructs:', len(list(substructs.keys())))
+    ensure(substructs)
+
+    substruct = random.choice(list(substructs.keys()))
+    print('chosen substruct:')
+    substruct.show()
+
+    old_typemap = copy.deepcopy(typemap)
+    # print('typemap:', typemap)
+    # print('field types:', [decayed_expr_type(field, typemap) for field in fields])
+    # print('substruct types:', [decayed_expr_type(field.name, typemap) for field in fields])
+    # print('parent types:', [decayed_expr_type(field.name.name, typemap) for field in fields])
+
+    # substruct = resolve_struct_def(decayed_expr_type(field.name, typemap), typemap)
+    # parent = resolve_struct_def(decayed_expr_type(field.name.name, typemap), typemap)
+    old_substruct = copy.deepcopy(substruct)
+    # old_parent = copy.deepcopy(parent)
+
+    # print('whiscash')
+    # print([decl.name for decl in substruct.decls])
+    ensure(substruct.decls)
+    endpoint = random.choice(substruct.decls)
+    flatten_upwards = random_bool(random, PROB_FLATTEN_UPWARDS)
+    print('oddish')
+    for parent, structRefs in substructs[substruct].items():
+        # TODO: Clean this up!!
+        # DO NOT SUBMIT until figuring out how to get field of `substruct` within parent.
+        substruct_idx = ast_util.struct_substruct_idx(parent, substruct, typemap)
+        print('substruct_idx:', substruct_idx)
+        parent_field_name = parent.decls[substruct_idx].name
+        print('parent field name:', parent_field_name)
+        moved_names = ast_util.flatten_fields(parent, parent_field_name, substruct, endpoint.name, flatten_upwards)
+        print('Moved names:')
+        print(moved_names)
+        print('structRefs:')
+        print(structRefs)
+        # Commit these changes to all StructRefs under this parent. We should
+        # only update references to fields that were moved.
+        for structRef in structRefs:
+            if structRef.field.name in moved_names:
+                print('structref before:')
+                structRef.show()
+                structRef.name = structRef.name.name
+                structRef.field.name = moved_names[structRef.field.name]
+                print('structref after:')
+                structRef.show()
+            else:
+                print("wingull -- not a moved field!")
+
+    # print('new typemap:', typemap)
+
+    # Call replace_subexprs(). Replace StructRef if its `name` field is a
+    # StructRef that resolves to the parent. Replace it with a new StructRef
+    # whose `name` is the `name` of the inner StructRef, and whose ID is the new
+    # field name from moved_names.
+    # def structref_replace(expr: Expression) -> Optional[Expression]:
+    #     if isinstance(expr, ca.StructRef) and isinstance(expr.name, ca.StructRef):  # nested StructRef
+    #         print('litten')
+    #         print('expression:')
+    #         print(expr)
+    #         # TODO NEXT: Try using `substruct` directly?
+    #         expr_type = resolve_struct_def(decayed_expr_type(expr.name, typemap), typemap)
+    #         print('expr type:', expr_type)
+    #         print('old substruct:', old_substruct)
+    #         # If we are referencing a field that got moved out of the substruct
+    #         if same_type(expr_type, substruct, typemap) and expr.field.name in moved_names:
+    #             print('torracat')
+    #             return ca.StructRef(expr.name.name, ".", moved_names[expr.field.name])
+    #     return None
+
+    # replace_subexprs(fn.body, structref_replace)
+
+
 RandomizationPass = Callable[[ca.FuncDef, ca.FileAST, Indices, Region, Random], None]
 
 RANDOMIZATION_PASSES: List[RandomizationPass] = [
-    perm_temp_for_expr,
-    perm_expand_expr,
-    perm_reorder_stmts,
-    perm_reorder_decls,
-    perm_add_mask,
-    perm_xor_zero,
-    perm_cast_simple,
-    perm_refer_to_var,
-    perm_float_literal,
-    perm_randomize_internal_type,
-    perm_randomize_external_type,
-    perm_randomize_function_type,
-    perm_split_assignment,
-    perm_sameline,
-    perm_ins_block,
-    perm_struct_ref,
-    perm_empty_stmt,
-    perm_condition,
-    perm_mult_zero,
-    perm_dummy_comma_expr,
-    perm_add_self_assignment,
-    perm_commutative,
-    perm_add_sub,
-    perm_inequalities,
-    perm_compound_assignment,
-    perm_remove_ast,
-    perm_duplicate_assignment,
-    perm_chain_assignment,
-    perm_long_chain_assignment,
-    perm_pad_var_decl,
-    perm_inline,
+    # perm_temp_for_expr,
+    # perm_expand_expr,
+    # perm_reorder_stmts,
+    # perm_reorder_decls,
+    # perm_add_mask,
+    # perm_xor_zero,
+    # perm_cast_simple,
+    # perm_refer_to_var,
+    # perm_float_literal,
+    # perm_randomize_internal_type,
+    # perm_randomize_external_type,
+    # perm_randomize_function_type,
+    # perm_split_assignment,
+    # perm_sameline,
+    # perm_ins_block,
+    # perm_struct_ref,
+    # perm_empty_stmt,
+    # perm_condition,
+    # perm_mult_zero,
+    # perm_dummy_comma_expr,
+    # perm_add_self_assignment,
+    # perm_commutative,
+    # perm_add_sub,
+    # perm_inequalities,
+    # perm_compound_assignment,
+    # perm_remove_ast,
+    # perm_duplicate_assignment,
+    # perm_chain_assignment,
+    # perm_long_chain_assignment,
+    # perm_pad_var_decl,
+    # perm_inline,
+    perm_flatten_struct,
 ]
 
 

--- a/src/randomizer.py
+++ b/src/randomizer.py
@@ -2290,15 +2290,28 @@ def perm_inline(
 # references via that parent.
 ParentRefs = Dict[ca.Struct, List[ca.StructRef]]
 
+### How to commit struct changes
+    # Two parts:
+    #  1) Commit change to struct definition
+    #  2) Commit change to any struct references (not restricted by region,
+    #     since we want the file to compile)
 def perm_flatten_struct(
     fn: ca.FuncDef, ast: ca.FileAST, indices: Indices, region: Region, random: Random
 ) -> None:
     """Moves fields from a nested struct into its parent struct. Only types used
     within the given region are affected."""
+    # No topological sort required for struct definitions with flatten. Will
+    # need to do this for FOLD.
+
     # TODO: With a get_mutable_node(node: Node) function, you could instead
     # just get a mutable copy of the parent struct once it is selected.
     ast_util.deepcopy_struct_defs(ast)
     typemap = build_typemap(ast, fn)
+    # print('typemap:')
+    # for struct_name in typemap.struct_defs.keys():
+    #     print(struct_name)
+    # for type_name in typemap.typedefs.keys():
+    #     print(type_name)
     substructs: Dict[ca.Struct, ParentRefs] = defaultdict(lambda: defaultdict(list))
 
     class StructRefVisitor(ca.NodeVisitor):
@@ -2308,63 +2321,125 @@ def perm_flatten_struct(
                 substruct = resolve_struct_def(decayed_expr_type(node.name, typemap), typemap)
                 parent = resolve_struct_def(decayed_expr_type(node.name.name, typemap), typemap)
                 substructs[substruct][parent].append(node)
+                self.generic_visit(node)
 
-    # Get all leaf fields in the region that are within a substruct. The fields
+    # Get all struct refs in the region that are within a substruct. The fields
     # must be accessed from a parent struct.
     StructRefVisitor().visit(fn)
+    print('Length of substructs:', len(substructs.keys()))
+    # print('SUBSTRUCTS:')
+    # for substruct, parentRef  in substructs.items():
+    #     print('  SUBSTRUCT:')
+    #     substruct.show()
+    #     for parent, structRefs in parentRef.items():
+    #         print('    PARENT:')
+    #         parent.show()
+    #         for structRef in structRefs:
+    #             print('      STRUCTREF:')
+    #             structRef.show()
+            
     ensure(substructs)
+
     substruct = random.choice(list(substructs.keys()))
+    print('chosen substruct:')
+    substruct.show()
+    old_substruct = substruct
+
+    print('num parents of substruct:', len(substructs[substruct].keys()))
+
+    parent = random.choice(list(substructs[substruct].keys()))
+    print('chosen parent:')
+    parent.show()
+
+    # We only want to flatten fields from the substruct into the selected
+    # parent. If the substruct is referenced from other parents, we'll make a
+    # copy of `substruct` in order to leave the other parents unaffected.
+    # 
+    # TODO: Test that it actually works in this case!
+    if len(substructs[substruct].keys()) > 1:
+        print('jirachi -- this substruct has multiple parents')
+        substruct = ast_util.copy_struct(ast, typemap, substruct)
+        # print('old == new substruct?', old_substruct is substruct)
+        # NOTE TO FUTURE SELF: This will break the struct_substruct_idx() call below!
+        # Solutions:
+        #  - Keep reference to old_substruct and new_substruct. Use
+        #    old_substruct below.
+        #  - Patch out the type of substruct in the parent with the new
+        #    substruct we just created. Requires a new method to patch in the
+        #    Struct for a particular field.
+        # 
+        # DO NOT SUBMIT until doing the patch method!! That'll be slightly
+        # cleaner and could be a useful down the line.
 
     ensure(substruct.decls)
     endpoint = random.choice(substruct.decls)
     flatten_upwards = random_bool(random, PROB_FLATTEN_UPWARDS)
+    print('endpoint field name:', endpoint.name)
+    print('flatten upwards?:', flatten_upwards)
 
-    for parent, structRefs in substructs[substruct].items():
-        substruct_idx = ast_util.struct_substruct_idx(parent, substruct, typemap)
-        parent_field_name = parent.decls[substruct_idx].name
-        moved_names = ast_util.flatten_fields(parent, parent_field_name, substruct, endpoint.name, flatten_upwards)
-        # Commit these changes to all StructRefs under this parent. We should
-        # only update references to fields that were moved.
-        for structRef in structRefs:
-            if structRef.field.name in moved_names:
-                structRef.name = structRef.name.name
-                structRef.field.name = moved_names[structRef.field.name]
+    # TODO: Clean this up!!
+    substruct_idx = ast_util.struct_substruct_idx(parent, old_substruct, typemap)
+    print('substruct_idx:', substruct_idx)
+    parent_field_name = parent.decls[substruct_idx].name
+    print('parent field name:', parent_field_name)
+    moved_names = ast_util.flatten_fields(parent, parent_field_name, substruct, endpoint.name, flatten_upwards)
+    print('new parent:')
+    parent.show()
+    print('new substruct:')
+    substruct.show()
+    print('Moved names:')
+    print(moved_names)
+    structRefs = substructs[old_substruct][parent]
+    print('structRefs:')
+    print(structRefs)
+    # Commit these changes to all StructRefs under this parent. We should
+    # only update references to fields that were moved.
+    for structRef in structRefs:
+        if structRef.field.name in moved_names:
+            print('structref before:')
+            structRef.show()
+            structRef.name = structRef.name.name
+            structRef.field.name = moved_names[structRef.field.name]
+            print('structref after:')
+            structRef.show()
+        else:
+            print("wingull -- not a moved field!")
 
 
 RandomizationPass = Callable[[ca.FuncDef, ca.FileAST, Indices, Region, Random], None]
 
 RANDOMIZATION_PASSES: List[RandomizationPass] = [
-    perm_temp_for_expr,
-    perm_expand_expr,
-    perm_reorder_stmts,
-    perm_reorder_decls,
-    perm_add_mask,
-    perm_xor_zero,
-    perm_cast_simple,
-    perm_refer_to_var,
-    perm_float_literal,
-    perm_randomize_internal_type,
-    perm_randomize_external_type,
-    perm_randomize_function_type,
-    perm_split_assignment,
-    perm_sameline,
-    perm_ins_block,
-    perm_struct_ref,
-    perm_empty_stmt,
-    perm_condition,
-    perm_mult_zero,
-    perm_dummy_comma_expr,
-    perm_add_self_assignment,
-    perm_commutative,
-    perm_add_sub,
-    perm_inequalities,
-    perm_compound_assignment,
-    perm_remove_ast,
-    perm_duplicate_assignment,
-    perm_chain_assignment,
-    perm_long_chain_assignment,
-    perm_pad_var_decl,
-    perm_inline,
+    # perm_temp_for_expr,
+    # perm_expand_expr,
+    # perm_reorder_stmts,
+    # perm_reorder_decls,
+    # perm_add_mask,
+    # perm_xor_zero,
+    # perm_cast_simple,
+    # perm_refer_to_var,
+    # perm_float_literal,
+    # perm_randomize_internal_type,
+    # perm_randomize_external_type,
+    # perm_randomize_function_type,
+    # perm_split_assignment,
+    # perm_sameline,
+    # perm_ins_block,
+    # perm_struct_ref,
+    # perm_empty_stmt,
+    # perm_condition,
+    # perm_mult_zero,
+    # perm_dummy_comma_expr,
+    # perm_add_self_assignment,
+    # perm_commutative,
+    # perm_add_sub,
+    # perm_inequalities,
+    # perm_compound_assignment,
+    # perm_remove_ast,
+    # perm_duplicate_assignment,
+    # perm_chain_assignment,
+    # perm_long_chain_assignment,
+    # perm_pad_var_decl,
+    # perm_inline,
     perm_flatten_struct,
 ]
 


### PR DESCRIPTION
Flattens fields out of a substruct mostly following [these flattening rules](https://gist.github.com/abaresk/132fe737825debb4d2c20ea92d2e4a48). Note, for simplicity we're not restricting the range for downward flattens.

Example: [original source](https://gist.github.com/abaresk/1188213fe0d72ddce142ff20f2c239b8), [permutations](https://gist.github.com/abaresk/620f69b4786de817902bdf9ce7b7caf6)