### PR TITLE
Spawn new Permuters when improvements are found

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -279,13 +279,16 @@ def multiprocess_worker(
                 break
             permuter_index, seed = queue_item
             if permuter_index > len(permuters) - 1:
-                # TODO why does this happen?
-                continue
-            permuter = permuters[permuter_index]
-            result = permuter.try_eval_candidate(seed)
-            if isinstance(result, CandidateResult) and permuter.should_output(result):
-                permuter.record_result(result)
-            output_queue.put((WorkDone(permuter_index, result), -1, None))
+                # TODO: why does this happen?
+                # also I haven't benchmarked this branch yet, but I suspect this is related to the slowdown
+                print("ERR")
+                pass
+            else:
+                permuter = permuters[permuter_index]
+                result = permuter.try_eval_candidate(seed)
+                if isinstance(result, CandidateResult) and permuter.should_output(result):
+                    permuter.record_result(result)
+                output_queue.put((WorkDone(permuter_index, result), -1, None))
             output_queue.put((NeedMoreWork(), -1, None))
     except KeyboardInterrupt:
         # Don't clutter the output with stack traces; Ctrl+C is the expected

--- a/src/main.py
+++ b/src/main.py
@@ -414,9 +414,8 @@ def run_inner(options: Options, heartbeat: Callable[[], None]) -> List[int]:
             permuter = context.permuters[permuter_index]
             result = permuter.try_eval_candidate(seed)
             new_permuter, found_zero = post_score(context, permuter, result, None)
-            if found_zero:
-                if options.stop_on_zero:
-                    break
+            if found_zero and options.stop_on_zero:
+                break
             if new_permuter:
                 print("Adding new permuter")
                 context.permuters.append(new_permuter)

--- a/src/permuter.py
+++ b/src/permuter.py
@@ -111,7 +111,6 @@ class Permuter:
             print("Defaulting to function: ", self.fn_name)
         else:
             self.fn_name = fn_name
-        self.unique_name = self.fn_name
 
         self._permutations = perm_parse(source)
 
@@ -132,6 +131,7 @@ class Permuter:
             self.base_hash,
             self.base_source,
         ) = self._create_and_score_base()
+        self.unique_name = f"{self.fn_name} ({self.base_score})"
         self.best_score = self.base_score
         self.hashes = {self.base_hash}
         self._cur_cand: Optional[Candidate] = None


### PR DESCRIPTION
This is very much a WIP. I've used it to match some stuff for PM already, but it can't be merged as-is because I don't know how to properly do multithreading in Python. There are 3 main issues I see:

1. I'm not sure if the "new permuter queue for each process" approach I have is ideal, and I'm not sure if the things I lifted into the context class are appropriate there. This is more of a design concern.
2. Quite often, right after a new Permuter is created, the worker proceses get an incoming task for the new permuter before they have added it to their internal list, so they are unable to run the task. I don't know how to write the permuter pass-off mechanism to avoid this scenario. For now I'm just discarding the task.
3. As the process goes and more sub-Permuters are created, there seems to be a considerable slowdown. I suspect this might be related to 2. but I'm not sure. 
4. I haven't really considered p@h yet, and I don't know how this will fit into it.

To-dos:
- [ ] Fix bug (2.) with task that we can't complete
- [ ] Fix gradual slowdown (3.)
- [ ] Add a constructor for Permuter which takes an existing Permuter and new source / a new AST and which doesn't log startup info to console
- [ ] Add args that influence when a new Permuter is created

Open to all and any suggestions for how to write this better.