### PR TITLE
Add perm_var_cond_block rule

### DIFF
--- a/default_weights.toml
+++ b/default_weights.toml
@@ -33,6 +33,7 @@ perm_chain_assignment = 5
 perm_long_chain_assignment = 3
 perm_pad_var_decl = 1
 perm_inline = 10
+perm_var_cond_block = 10
 
 [ido]
 perm_float_literal = 10


### PR DESCRIPTION
This helps with useless moves emitted by gcc 2.8.1 by turning
```
[statements]
```
into
```c
if (variable)
{
    [statements]
}
else
{
    [statements]
}
```
Examples:
https://decomp.me/scratch/hQYzv -> https://decomp.me/scratch/LJdek
https://decomp.me/scratch/U0w1R -> https://decomp.me/scratch/S9QUe

Marking this as a draft for now as the code to generate `if (variable1 || variable2)` by trying to weed out duplicate expressions doesn't yet work.