### PR TITLE
Allow passing arguments to main() from external source

### DIFF
--- a/import.py
+++ b/import.py
@@ -769,60 +769,7 @@ def write_to_file(cont: str, filename: str) -> None:
         f.write(cont)
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(
-        description="""Import a function for use with the permuter.
-        Will create a new directory nonmatchings/<funcname>-<id>/."""
-    )
-    parser.add_argument(
-        "c_file",
-        help="""File containing the function.
-        Assumes that the file can be built with 'make' to create an .o file.""",
-    )
-    parser.add_argument(
-        "asm_file_or_func_name",
-        metavar="{asm_file|func_name}",
-        help="""File containing assembly for the function.
-        Must start with 'glabel <function_name>' and contain no other functions.
-        Alternatively, a function name can be given, which will be looked for in
-        all GLOBAL_ASM blocks in the C file.""",
-    )
-    parser.add_argument(
-        "make_flags",
-        nargs="*",
-        help="Arguments to pass to 'make'. PERMUTER=1 will always be passed.",
-    )
-    parser.add_argument(
-        "--keep", action="store_true", help="Keep the directory on error."
-    )
-    settings_files = ", ".join(SETTINGS_FILES[:-1]) + " or " + SETTINGS_FILES[-1]
-    parser.add_argument(
-        "--preserve-macros",
-        metavar="REGEX",
-        dest="preserve_macros_regex",
-        help=f"""Regex for which macros to preserve, or empty string for no macros.
-        By default, this is read from {settings_files} in a parent directory of
-        the imported file. Type information is also read from this file.""",
-    )
-    parser.add_argument(
-        "--no-prune",
-        dest="prune",
-        action="store_false",
-        help="""Don't minimize the source to keep only the imported function and
-        functions/struct/variables that it uses. Normally this behavior is
-        useful to make the permuter faster, but in cases where unrelated code
-        affects the generated assembly asm it can be necessary to turn off.
-        Note that regardless of this setting the permuter always removes all
-        other functions by replacing them with declarations.""",
-    )
-    parser.add_argument(
-        "--decompme",
-        dest="decompme",
-        action="store_true",
-        help="""Upload the function to decomp.me to share with other people,
-        instead of importing.""",
-    )
-    args = parser.parse_args()
+def main(args) -> None:
 
     root_dir = find_root_dir(
         args.c_file, SETTINGS_FILES + ["Makefile", "makefile", "build.ninja"]
@@ -940,4 +887,57 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(
+        description="""Import a function for use with the permuter.
+        Will create a new directory nonmatchings/<funcname>-<id>/."""
+    )
+    parser.add_argument(
+        "c_file",
+        help="""File containing the function.
+        Assumes that the file can be built with 'make' to create an .o file.""",
+    )
+    parser.add_argument(
+        "asm_file_or_func_name",
+        metavar="{asm_file|func_name}",
+        help="""File containing assembly for the function.
+        Must start with 'glabel <function_name>' and contain no other functions.
+        Alternatively, a function name can be given, which will be looked for in
+        all GLOBAL_ASM blocks in the C file.""",
+    )
+    parser.add_argument(
+        "make_flags",
+        nargs="*",
+        help="Arguments to pass to 'make'. PERMUTER=1 will always be passed.",
+    )
+    parser.add_argument(
+        "--keep", action="store_true", help="Keep the directory on error."
+    )
+    settings_files = ", ".join(SETTINGS_FILES[:-1]) + " or " + SETTINGS_FILES[-1]
+    parser.add_argument(
+        "--preserve-macros",
+        metavar="REGEX",
+        dest="preserve_macros_regex",
+        help=f"""Regex for which macros to preserve, or empty string for no macros.
+        By default, this is read from {settings_files} in a parent directory of
+        the imported file. Type information is also read from this file.""",
+    )
+    parser.add_argument(
+        "--no-prune",
+        dest="prune",
+        action="store_false",
+        help="""Don't minimize the source to keep only the imported function and
+        functions/struct/variables that it uses. Normally this behavior is
+        useful to make the permuter faster, but in cases where unrelated code
+        affects the generated assembly asm it can be necessary to turn off.
+        Note that regardless of this setting the permuter always removes all
+        other functions by replacing them with declarations.""",
+    )
+    parser.add_argument(
+        "--decompme",
+        dest="decompme",
+        action="store_true",
+        help="""Upload the function to decomp.me to share with other people,
+        instead of importing.""",
+    )
+    args = parser.parse_args()
+    main(args)

--- a/import.py
+++ b/import.py
@@ -769,7 +769,7 @@ def write_to_file(cont: str, filename: str) -> None:
         f.write(cont)
 
 
-def main(arg_list) -> None:
+def main(arg_list: List[str]) -> None:
     parser = argparse.ArgumentParser(
         description="""Import a function for use with the permuter.
         Will create a new directory nonmatchings/<funcname>-<id>/."""

--- a/import.py
+++ b/import.py
@@ -823,6 +823,7 @@ def main(arg_list) -> None:
         instead of importing.""",
     )
     args = parser.parse_args(arg_list)
+    
     root_dir = find_root_dir(
         args.c_file, SETTINGS_FILES + ["Makefile", "makefile", "build.ninja"]
     )

--- a/import.py
+++ b/import.py
@@ -769,8 +769,61 @@ def write_to_file(cont: str, filename: str) -> None:
         f.write(cont)
 
 
-def main(args) -> None:
-
+def main(arg_list) -> None:
+    parser = argparse.ArgumentParser(
+        description="""Import a function for use with the permuter.
+        Will create a new directory nonmatchings/<funcname>-<id>/."""
+    )
+    parser.add_argument(
+        "c_file",
+        help="""File containing the function.
+        Assumes that the file can be built with 'make' to create an .o file.""",
+    )
+    parser.add_argument(
+        "asm_file_or_func_name",
+        metavar="{asm_file|func_name}",
+        help="""File containing assembly for the function.
+        Must start with 'glabel <function_name>' and contain no other functions.
+        Alternatively, a function name can be given, which will be looked for in
+        all GLOBAL_ASM blocks in the C file.""",
+    )
+    parser.add_argument(
+        "make_flags",
+        nargs="*",
+        help="Arguments to pass to 'make'. PERMUTER=1 will always be passed.",
+    )
+    parser.add_argument(
+        "--keep", action="store_true", help="Keep the directory on error."
+    )
+    settings_files = ", ".join(SETTINGS_FILES[:-1]) + " or " + SETTINGS_FILES[-1]
+    parser.add_argument(
+        "--preserve-macros",
+        metavar="REGEX",
+        dest="preserve_macros_regex",
+        help=f"""Regex for which macros to preserve, or empty string for no macros.
+        By default, this is read from {settings_files} in a parent directory of
+        the imported file. Type information is also read from this file.""",
+    )
+    parser.add_argument(
+        "--no-prune",
+        dest="prune",
+        action="store_false",
+        help="""Don't minimize the source to keep only the imported function and
+        functions/struct/variables that it uses. Normally this behavior is
+        useful to make the permuter faster, but in cases where unrelated code
+        affects the generated assembly asm it can be necessary to turn off.
+        Note that regardless of this setting the permuter always removes all
+        other functions by replacing them with declarations.""",
+    )
+    parser.add_argument(
+        "--decompme",
+        dest="decompme",
+        action="store_true",
+        help="""Upload the function to decomp.me to share with other people,
+        instead of importing.""",
+    )
+    args = parser.parse_args(arg_list)
+    print(args)
     root_dir = find_root_dir(
         args.c_file, SETTINGS_FILES + ["Makefile", "makefile", "build.ninja"]
     )
@@ -887,57 +940,5 @@ def main(args) -> None:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description="""Import a function for use with the permuter.
-        Will create a new directory nonmatchings/<funcname>-<id>/."""
-    )
-    parser.add_argument(
-        "c_file",
-        help="""File containing the function.
-        Assumes that the file can be built with 'make' to create an .o file.""",
-    )
-    parser.add_argument(
-        "asm_file_or_func_name",
-        metavar="{asm_file|func_name}",
-        help="""File containing assembly for the function.
-        Must start with 'glabel <function_name>' and contain no other functions.
-        Alternatively, a function name can be given, which will be looked for in
-        all GLOBAL_ASM blocks in the C file.""",
-    )
-    parser.add_argument(
-        "make_flags",
-        nargs="*",
-        help="Arguments to pass to 'make'. PERMUTER=1 will always be passed.",
-    )
-    parser.add_argument(
-        "--keep", action="store_true", help="Keep the directory on error."
-    )
-    settings_files = ", ".join(SETTINGS_FILES[:-1]) + " or " + SETTINGS_FILES[-1]
-    parser.add_argument(
-        "--preserve-macros",
-        metavar="REGEX",
-        dest="preserve_macros_regex",
-        help=f"""Regex for which macros to preserve, or empty string for no macros.
-        By default, this is read from {settings_files} in a parent directory of
-        the imported file. Type information is also read from this file.""",
-    )
-    parser.add_argument(
-        "--no-prune",
-        dest="prune",
-        action="store_false",
-        help="""Don't minimize the source to keep only the imported function and
-        functions/struct/variables that it uses. Normally this behavior is
-        useful to make the permuter faster, but in cases where unrelated code
-        affects the generated assembly asm it can be necessary to turn off.
-        Note that regardless of this setting the permuter always removes all
-        other functions by replacing them with declarations.""",
-    )
-    parser.add_argument(
-        "--decompme",
-        dest="decompme",
-        action="store_true",
-        help="""Upload the function to decomp.me to share with other people,
-        instead of importing.""",
-    )
-    args = parser.parse_args()
-    main(args)
+    #Default: Call main with passed args. [1:] to leave off `./import.py` itself.
+    main(sys.argv[1:])

--- a/import.py
+++ b/import.py
@@ -823,7 +823,7 @@ def main(arg_list) -> None:
         instead of importing.""",
     )
     args = parser.parse_args(arg_list)
-    
+
     root_dir = find_root_dir(
         args.c_file, SETTINGS_FILES + ["Makefile", "makefile", "build.ninja"]
     )

--- a/import.py
+++ b/import.py
@@ -823,7 +823,6 @@ def main(arg_list) -> None:
         instead of importing.""",
     )
     args = parser.parse_args(arg_list)
-    print(args)
     root_dir = find_root_dir(
         args.c_file, SETTINGS_FILES + ["Makefile", "makefile", "build.ninja"]
     )


### PR DESCRIPTION
Hi there! Thanks for making decomp-permuter, I've found it immensely helpful.

I'd like to leverage `import.py` for use in my own project. Specifically, I'm trying to make a Python script that will automate most of the process of creating a decomp.me page from raw Assembly. This includes things like putting rodata into the .asm file prior to the initial decompilation. In order to create the decomp.me page, I'm currently doing:

```
 import_string = f'tools/decomp-permuter/import.py {c_filename} {asm_filename} --decompme'
    print(f"Calling {import_string}")
    os.system(import_string)
```

But this calling out to the OS seems a little clumsy. It would be nice if I could call import.py from within Python itself, by importing import.py and then calling its `main()` function. However, since `main()` runs `argparse` from within, rather than taking arguments, there's no way (that I'm aware of) to call `main()` externally and give it arguments, without messing with `sys.argv` during runtime.

This PR simply moves the argument parsing into the `if __name__ == __main__` block, and then calls `main()` with the arguments that were parsed. This way, `main()` can also be called with args that come from an alternative source, rather than only what `argparse` finds.

Ultimately, this change should not at all affect using `decomp-permuter` as a standalone utility, but should make it much easier to integrate it into other Python workflows.