### PR TITLE
decomp.me: Use new scratch claim token

### DIFF
--- a/import.py
+++ b/import.py
@@ -904,7 +904,7 @@ def main(arg_list: List[str]) -> None:
                 json_data: Dict[str, str] = json.loads(resp)
                 if "slug" in json_data:
                     slug = json_data["slug"]
-                    token = json_data["claim_token"]
+                    token = json_data.get("claim_token")
                     if token:
                         print(f"https://decomp.me/scratch/{slug}/claim?token={token}")
                     else:

--- a/import.py
+++ b/import.py
@@ -904,7 +904,11 @@ def main(arg_list: List[str]) -> None:
                 json_data: Dict[str, str] = json.loads(resp)
                 if "slug" in json_data:
                     slug = json_data["slug"]
-                    print(f"https://decomp.me/scratch/{slug}")
+                    token = json_data["claim_token"]
+                    if token:
+                        print(f"https://decomp.me/scratch/{slug}/claim?token={token}")
+                    else:
+                        print(f"https://decomp.me/scratch/{slug}")
                 else:
                     error = json_data.get("error", resp)
                     print(f"Server error: {error}")


### PR DESCRIPTION
A change introduced in https://github.com/decompme/decomp.me/pull/945

It's no longer possible to claim a scratch without a token. This new endpoint will automatically claim the scratch when visited.