### PR TITLE
 #67 Add Levenshtein as a diff algorithm option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ This tool supports MIPS (compiled by IDO, possibly GCC), PowerPC, and ARM32 asse
 `./permuter.py directory/` runs the permuter; see below for the meaning of the directory.
 Pass `-h` to see possible flags. `-j` is suggested (enables multi-threaded mode).
 
-You'll first need to install a couple of prerequisites: `python3 -m pip install pycparser pynacl toml` (also `dataclasses` if on Python 3.6 or below)
+You'll first need to install a couple of prerequisites: `python3 -m pip install pycparser pynacl toml Levenshtein` (also `dataclasses` if on Python 3.6 or below)
 `pynacl` is optional and only necessary for the "permuter@home" networking feature.
+`Levenshtein` is optional and only necessary for using the Levenshtein diff algorithm (difflib is used by default).
 
 The permuter expects as input one or more directory containing:
   - a .c file with a single function,

--- a/src/main.py
+++ b/src/main.py
@@ -68,6 +68,7 @@ class Options:
     show_timings: bool = False
     print_diffs: bool = False
     stack_differences: bool = False
+    algorithm: str = "difflib"
     abort_exceptions: bool = False
     better_only: bool = False
     best_only: bool = False
@@ -350,6 +351,7 @@ def run_inner(options: Options, heartbeat: Callable[[], None]) -> List[int]:
         scorer = Scorer(
             target_o,
             stack_differences=options.stack_differences,
+            algorithm=options.algorithm,
             debug_mode=options.debug_mode,
         )
         c_source = preprocess(base_c)
@@ -670,6 +672,13 @@ def main() -> None:
         help="Take stack differences into account when computing the score.",
     )
     parser.add_argument(
+        "--algorithm",
+        dest="algorithm",
+        default="difflib",
+        choices=["difflib", "levenshtein"],
+        help="Diff algorithm to use",
+    )
+    parser.add_argument(
         "--keep-prob",
         dest="keep_prob",
         metavar="PROB",
@@ -747,6 +756,7 @@ def main() -> None:
         best_only=args.best_only,
         quiet=args.quiet,
         stack_differences=args.stack_differences,
+        algorithm=args.algorithm,
         stop_on_zero=args.stop_on_zero,
         keep_prob=args.keep_prob,
         force_seed=args.force_seed,

--- a/src/net/client.py
+++ b/src/net/client.py
@@ -94,6 +94,7 @@ def make_portable_permuter(permuter: Permuter) -> PermuterData:
         keep_prob=permuter.keep_prob,
         need_profiler=permuter.need_profiler,
         stack_differences=permuter.scorer.stack_differences,
+        algorithm=permuter.scorer.algorithm,
         randomization_weights=permuter.randomization_weights,
         compile_script=compile_script,
         source=permuter.source,

--- a/src/net/core.py
+++ b/src/net/core.py
@@ -53,6 +53,7 @@ class PermuterData:
     keep_prob: float
     need_profiler: bool
     stack_differences: bool
+    algorithm: str
     randomization_weights: Mapping[str, float]
     compile_script: str
     source: str
@@ -70,6 +71,7 @@ def permuter_data_from_json(
         keep_prob=json_prop(obj, "keep_prob", float),
         need_profiler=json_prop(obj, "need_profiler", bool),
         stack_differences=json_prop(obj, "stack_differences", bool),
+        algorithm=json_prop(obj, "algorithm", str),
         compile_script=json_prop(obj, "compile_script", str),
         randomization_weights=json_dict(
             json_prop(obj, "randomization_weights", dict, {}), float
@@ -88,6 +90,7 @@ def permuter_data_to_json(perm: PermuterData) -> dict:
         "keep_prob": perm.keep_prob,
         "need_profiler": perm.need_profiler,
         "stack_differences": perm.stack_differences,
+        "algorithm": perm.algorithm,
         "randomization_weights": perm.randomization_weights,
         "compile_script": perm.compile_script,
     }

--- a/src/net/evaluator.py
+++ b/src/net/evaluator.py
@@ -73,7 +73,10 @@ def _create_permuter(data: PermuterData) -> Permuter:
         with os.fdopen(fd, "wb") as f:
             f.write(data.target_o_bin)
         scorer = Scorer(
-            target_o=path, stack_differences=data.stack_differences, debug_mode=False
+            target_o=path,
+            stack_differences=data.stack_differences,
+            algorithm=data.algorithm,
+            debug_mode=False,
         )
     finally:
         os.unlink(path)


### PR DESCRIPTION
#67
I have tested the local version of these changes, don't know if I got the permuter@home related stuff correct or not.

Cribs very, very heavily off simonlindholm/asm-differ@846a069

Leaves difflib as the default

Motivated by a unique circumstance in the MK64 decomp where the difflib and Levenshtein algorithms disagree ever so slightly, which made it hard to interpret the permuter's output when comparing it to asm-differ's.