### PR TITLE
Add asm_prelude_file setting for import.py

### DIFF
--- a/import.py
+++ b/import.py
@@ -710,7 +710,7 @@ def write_compile_command(compiler: List[str], cwd: str, out_file: str) -> None:
     os.chmod(out_file, 0o755)
 
 
-def write_asm(asm_prelude_file: str, asm_cont: str, out_file: str) -> None:
+def write_asm(asm_prelude_file: Optional[str], asm_cont: str, out_file: str) -> None:
     asm_prelude_file = asm_prelude_file or DEFAULT_ASM_PRELUDE_FILE
     with open(asm_prelude_file, "r") as p:
         asm_prelude = p.read()

--- a/import.py
+++ b/import.py
@@ -43,7 +43,7 @@ cpp_cmd = homebrew_gcc_cpp() if is_macos else "cpp"
 make_cmd = "gmake" if is_macos else "make"
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
-prelude_file = os.path.join(dir_path, "prelude.inc")
+DEFAULT_ASM_PRELUDE_FILE = os.path.join(dir_path, "prelude.inc")
 
 DEFAULT_AS_CMDLINE: List[str] = ["mips-linux-gnu-as", "-march=vr4300", "-mabi=32"]
 
@@ -710,8 +710,9 @@ def write_compile_command(compiler: List[str], cwd: str, out_file: str) -> None:
     os.chmod(out_file, 0o755)
 
 
-def write_asm(asm_cont: str, out_file: str) -> None:
-    with open(prelude_file, "r") as p:
+def write_asm(asm_prelude_file: str, asm_cont: str, out_file: str) -> None:
+    asm_prelude_file = asm_prelude_file or DEFAULT_ASM_PRELUDE_FILE
+    with open(asm_prelude_file, "r") as p:
         asm_prelude = p.read()
     with open(out_file, "w", encoding="utf-8") as f:
         f.write(asm_prelude)
@@ -846,6 +847,7 @@ def main(arg_list: List[str]) -> None:
     build_system = settings.get("build_system", "make")
     compiler = settings.get("compiler_command")
     assembler = settings.get("assembler_command")
+    asm_prelude_file = settings.get("asm_prelude_file")
     make_flags = args.make_flags
 
     compiler_type = settings.get("compiler_type")
@@ -932,7 +934,7 @@ def main(arg_list: List[str]) -> None:
         write_to_file(source, base_c_file)
         create_write_settings_toml(func_name, compiler_type, settings_file)
         write_compile_command(compiler, root_dir, compile_script)
-        write_asm(asm_cont, target_s_file)
+        write_asm(asm_prelude_file, asm_cont, target_s_file)
         compile_asm(assembler, root_dir, target_s_file, target_o_file)
         if compilable_source is not None:
             compile_base(compile_script, compilable_source, base_c_file, base_o_file)


### PR DESCRIPTION
The default prelude.inc assumes MIPS. I'm not sure if there's already a way to turn that off, but having a project-wide setting seems useful