### PR TITLE
Implement a basic speed setting to reduce the resources spent on permuting

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -764,8 +764,8 @@ def main() -> None:
         dest="speed",
         type=int,
         help="Speed% to run at to reduce resources. Default 100",
-        choices=range(0,101),
-        metavar="[0-100]",
+        choices=range(1,101),
+        metavar="[1-100]",
         default=100,
     )
 

--- a/src/permuter.py
+++ b/src/permuter.py
@@ -91,6 +91,7 @@ class Permuter:
         better_only: bool,
         score_threshold: Optional[int],
         debug_mode: bool,
+        speed: int,
     ) -> None:
         self.dir = dir
         self.compiler = compiler
@@ -137,6 +138,7 @@ class Permuter:
         self._cur_cand: Optional[Candidate] = None
         self._last_score: Optional[int] = None
         self._score_for_source: Dict[bytes, int] = {}
+        self.speed = speed
 
     def _create_and_score_base(self) -> Tuple[int, str, str]:
         base_source, eval_state = perm_evaluate_one(self._permutations)


### PR DESCRIPTION
The goal here is just that I don't want (or need) the permuter to run at max speed and taking my CPU up to max temperatures for minutes at a time, so I wanted a way to reduce the speed of execution and make it more idle friendly.

This is almost certainly not the best way to do this, so feel free to replace this with a nicer/better version, I just wanted to get *something* working.