### PR TITLE
Custom objdump support, formatting adjustments to assembly in debug output, and minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ __pycache__/
 /nonmatchings
 .vscode/
 pah.conf
+/.venv/
+/venv/

--- a/import.py
+++ b/import.py
@@ -779,13 +779,22 @@ def compile_base(compile_script: str, source: str, c_file: str, out_file: str) -
 
 
 def create_write_settings_toml(
-    func_name: str, compiler_type: str, filename: str
+    func_name: str,
+    compiler_type: str,
+    filename: str,
+    objdump_path: Optional[str] = None,
+    objdump_args: Optional[str] = None,
 ) -> None:
     rand_weights = get_default_randomization_weights(compiler_type)
 
     with open(filename, "w", encoding="utf-8") as f:
         f.write(f'func_name = "{func_name}"\n')
-        f.write(f'compiler_type = "{compiler_type}"\n\n')
+        f.write(f'compiler_type = "{compiler_type}"\n')
+        if objdump_path:
+            f.write(f'objdump_path = "{objdump_path}"\n')
+        if objdump_args:
+            f.write(f'objdump_args = "{objdump_args}"\n')
+        f.write("\n")
 
         f.write("# uncomment lines below to customize randomization pass weights\n")
         f.write("# see --help=randomization-passes for descriptions\n")
@@ -900,6 +909,8 @@ def main(arg_list: List[str]) -> None:
     compiler_str = get_setting("compiler_command") or ""
     assembler_str = get_setting("assembler_command") or ""
     asm_prelude_file = get_setting("asm_prelude_file")
+    objdump_path = get_setting("objdump_path")
+    objdump_args = get_setting("objdump_args")
     if asm_prelude_file is not None:
         asm_prelude_file = os.path.join(root_dir, asm_prelude_file)
     make_flags = args.make_flags
@@ -983,7 +994,9 @@ def main(arg_list: List[str]) -> None:
 
     try:
         write_to_file(source, base_c_file)
-        create_write_settings_toml(func_name, compiler_type, settings_file)
+        create_write_settings_toml(
+            func_name, compiler_type, settings_file, objdump_path, objdump_args
+        )
         write_compile_command(compiler, root_dir, compile_script)
         write_asm(asm_prelude_file, asm_cont, target_s_file)
         compile_asm(assembler, root_dir, target_s_file, target_o_file)

--- a/import.py
+++ b/import.py
@@ -13,7 +13,18 @@ import subprocess
 import sys
 import toml
 import fnmatch
-from typing import Callable, Dict, List, Match, Mapping, Optional, Pattern, Tuple
+from typing import (
+    Callable,
+    Dict,
+    List,
+    Match,
+    Mapping,
+    Optional,
+    Pattern,
+    Tuple,
+    Set,
+    cast,
+)
 import urllib.request
 import urllib.parse
 
@@ -72,8 +83,8 @@ def formatcmd(cmdline: List[str]) -> str:
 
 def prune_asm(asm_cont: str) -> Tuple[str, str]:
     func_name = None
-    asm_lines = []
-    late_rodata = []
+    asm_lines: List[str] = []
+    late_rodata: List[str] = []
     cur_section = ".text"
     for line in asm_cont.splitlines(keepends=True):
         changed_section = False
@@ -196,7 +207,7 @@ def parse_asm(
 
 
 def create_directory(func_name: str) -> str:
-    os.makedirs(f"nonmatchings/", exist_ok=True)
+    os.makedirs("nonmatchings/", exist_ok=True)
     ctr = 0
     while True:
         ctr += 1
@@ -226,7 +237,7 @@ def find_root_dir(filename: str, pattern: List[str]) -> Optional[str]:
 def fixup_build_command(
     parts: List[str], ignore_part: str
 ) -> Tuple[List[str], Optional[List[str]]]:
-    res = []
+    res: List[str] = []
     skip_count = 0
     assembler = None
     for part in parts:
@@ -292,8 +303,8 @@ def find_build_command_line(
         .split("\n")
     )
 
-    output = []
-    close_match = ""
+    output: List[List[str]] = []
+    close_match: str = ""
 
     assembler = DEFAULT_AS_CMDLINE
     for line in debug_output:
@@ -360,10 +371,10 @@ PreserveMacros = Tuple[Pattern[str], Callable[[str], str]]
 def build_preserve_macros(
     cwd: str, preserve_regex: Optional[str], settings: Mapping[str, object]
 ) -> Optional[PreserveMacros]:
-
     subdata = settings.get("preserve_macros", {})
     assert isinstance(subdata, dict)
-    regexes = []
+    subdata = cast(Dict[str, str], subdata)
+    regexes: List[Tuple[re.Pattern[str], str]] = []
     for regex, value in subdata.items():
         assert isinstance(value, str)
         regexes.append((re.compile(f"^(?:{regex})$"), value))
@@ -432,9 +443,9 @@ def preprocess_c_with_macros(
     # function declarations for them in a specially demarcated section of
     # the file. When the compiler runs, this section will be replaced by
     # the real defines and the preprocessor invoked once more.
-    late_defines = []
-    lines = []
-    graph = defaultdict(set)
+    late_defines: List[Tuple[str, str]] = []
+    lines: List[str] = []
+    graph: Dict[str, Set[str]] = defaultdict(set)
     reg_token = re.compile(r"[a-zA-Z0-9_]+")
     for line in source.splitlines():
         is_macro = line.startswith("_permuter define ")
@@ -475,7 +486,7 @@ def preprocess_c_with_macros(
                 graph[name].add(name2)
 
     # Prune away (recursively) unused macros, for cleanliness.
-    used_anywhere = set()
+    used_anywhere: Set[str] = set()
     used_by_nonmacro = graph[""]
     queue = [""]
     while queue:
@@ -497,7 +508,7 @@ def preprocess_c_with_macros(
         else:
             return f"extern {typ} {name};"
 
-    used_macros = [name for (name, after) in late_defines if name in used_by_nonmacro]
+    used_macros = [name for (name, _after) in late_defines if name in used_by_nonmacro]
 
     return (
         "\n".join(
@@ -659,8 +670,10 @@ def get_decompme_compiler_name(
 ) -> str:
     decompme_settings = settings.get("decompme", {})
     assert isinstance(decompme_settings, dict)
+    decompme_settings = cast(Dict[str, str], decompme_settings)
     compiler_mappings = decompme_settings.get("compilers", {})
     assert isinstance(compiler_mappings, dict)
+    compiler_mappings = cast(Dict[str, str], compiler_mappings)
 
     compiler_path = compiler[0]
 
@@ -670,13 +683,15 @@ def get_decompme_compiler_name(
         if fnmatch.fnmatch(compiler_path, path):
             return compiler_name
 
+    available_ids: List[str] = []
     try:
         with urllib.request.urlopen(f"{api_base}/api/compilers") as f:
             json_data = json.load(f)
             available = json_data["compilers"]
             if not isinstance(available, dict):
                 raise Exception("compilers must be a dict")
-            available_ids = available.keys()
+            available = cast(Dict[str, str], available)
+            available_ids = list(available.keys())
     except Exception as e:
         print(f"Failed to request available compilers from decomp.me:\n{e}")
 
@@ -714,7 +729,6 @@ def get_compiler_flags(cmdline: List[str]) -> str:
 
 
 def write_compile_command(compiler: List[str], cwd: str, out_file: str) -> None:
-
     with open(out_file, "w", encoding="utf-8") as f:
         f.write("#!/usr/bin/env bash\n")
         f.write('INPUT="$(realpath "$1")"\n')
@@ -767,7 +781,6 @@ def compile_base(compile_script: str, source: str, c_file: str, out_file: str) -
 def create_write_settings_toml(
     func_name: str, compiler_type: str, filename: str
 ) -> None:
-
     rand_weights = get_default_randomization_weights(compiler_type)
 
     with open(filename, "w", encoding="utf-8") as f:
@@ -852,7 +865,7 @@ def main(arg_list: List[str]) -> None:
     )
 
     if not root_dir:
-        print(f"Can't find root dir of project!", file=sys.stderr)
+        print("Can't find root dir of project!", file=sys.stderr)
         sys.exit(1)
 
     settings: Mapping[str, object] = {}
@@ -861,7 +874,7 @@ def main(arg_list: List[str]) -> None:
             with open(args.settings_file) as f:
                 settings = toml.load(f)
         else:
-            print(f"Can't find settings file!", file=sys.stderr)
+            print("Can't find settings file!", file=sys.stderr)
             sys.exit(1)
     else:
         for filename in SETTINGS_FILES:
@@ -906,9 +919,9 @@ def main(arg_list: List[str]) -> None:
     print(f"Function name: {func_name}")
 
     if compiler_str or assembler_str:
-        assert (
-            build_system_raw is None
-        ), "Must not specify both build system and compiler/assembler"
+        assert build_system_raw is None, (
+            "Must not specify both build system and compiler/assembler"
+        )
         compiler = shlex.split(compiler_str)
         assembler = shlex.split(assembler_str)
     else:

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -2,7 +2,7 @@ import os
 import toml
 from pathlib import Path
 import typing
-from typing import List, Mapping, NoReturn, Optional, Type, TypeVar
+from typing import List, Mapping, NoReturn, Optional, Type, TypeVar, Any, Dict, cast
 from .error import CandidateConstructionFailure
 
 T = TypeVar("T")
@@ -54,7 +54,8 @@ def get_default_randomization_weights(compiler_type: str) -> Mapping[str, float]
             raise CandidateConstructionFailure(
                 f"Unable to find compiler type {compiler_type} in default_weights.toml"
             )
-        compiler_weights = json_dict(json_prop(obj, compiler_type, dict), float)
+        compiler_type_prop = cast(Dict[Any, Any], json_prop(obj, compiler_type, dict))
+        compiler_weights = json_dict(compiler_type_prop, float)
 
         return merge_randomization_weights(base_weights, compiler_weights)
 
@@ -89,15 +90,15 @@ def json_prop(
     return _json_as_type("Member " + prop, value, t)
 
 
-def json_array(obj: list, t: Type[T]) -> List[T]:
-    ret = []
+def json_array(obj: List[Any], t: Type[T]) -> List[T]:
+    ret: List[T] = []
     for elem in obj:
         ret.append(_json_as_type("Array elements", elem, t))
     return ret
 
 
-def json_dict(obj: dict, t: Type[T]) -> Mapping[str, T]:
-    ret = {}
+def json_dict(obj: Dict[Any, Any], t: Type[T]) -> Mapping[str, T]:
+    ret: Dict[str, T] = {}
     for key, value in obj.items():
         assert isinstance(key, str), "JSON/TOML can only have string keys"
         ret[key] = _json_as_type("Dict entries", value, t)

--- a/src/main.py
+++ b/src/main.py
@@ -267,7 +267,7 @@ def multiprocess_worker(
 
             if permuter.speed != 100:
                 end = time.time()
-                
+
                 sleep_time = (end - start) * ((100 / permuter.speed) - 1)
                 time.sleep(sleep_time)
 
@@ -763,8 +763,8 @@ def main() -> None:
         "--speed",
         dest="speed",
         type=int,
-        help="Speed% to run at to reduce resources. Default 100",
-        choices=range(1,101),
+        help="Speed%% to run at to reduce resources. Default 100",
+        choices=range(1, 101),
         metavar="[1-100]",
         default=100,
     )

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,7 @@ import re
 import sys
 import threading
 import time
+import shlex
 
 from typing import (
     Callable,
@@ -55,6 +56,7 @@ from .scorer import Scorer
 
 MIN_PRIO = 0.01
 MAX_PRIO = 2.0
+
 # The probability that the randomizer continues transforming the output it
 # generated last time.
 DEFAULT_RAND_KEEP_PROB = 0.6
@@ -358,11 +360,20 @@ def run_inner(options: Options, heartbeat: Callable[[], None]) -> List[int]:
         compiler = Compiler(
             compile_cmd, show_errors=options.show_errors, debug_mode=options.debug_mode
         )
+
+        objdump_path = json_prop(settings, "objdump_path", str, "") or None
+        objdump_args = json_prop(settings, "objdump_args", str, "") or None
+
+        if objdump_args is not None:
+            objdump_args = shlex.split(objdump_args)
+
         scorer = Scorer(
             target_o,
             stack_differences=options.stack_differences,
             algorithm=options.algorithm,
             debug_mode=options.debug_mode,
+            objdump_path=objdump_path,
+            objdump_args=objdump_args,
         )
         c_source = preprocess(base_c)
 

--- a/src/main.py
+++ b/src/main.py
@@ -53,6 +53,7 @@ from .printer import Printer
 from .profiler import Profiler
 from .randomizer import RANDOMIZATION_PASSES
 from .scorer import Scorer
+from .objdump import DEFAULT_IGN_BRANCH_TARGETS
 
 MIN_PRIO = 0.01
 MAX_PRIO = 2.0
@@ -85,6 +86,7 @@ class Options:
     no_context_output: bool = False
     debug_mode: bool = False
     speed: int = 100
+    ign_branch_targets: bool = DEFAULT_IGN_BRANCH_TARGETS
 
 
 def restricted_float(lo: float, hi: float) -> Callable[[str], float]:
@@ -374,6 +376,7 @@ def run_inner(options: Options, heartbeat: Callable[[], None]) -> List[int]:
             debug_mode=options.debug_mode,
             objdump_path=objdump_path,
             objdump_args=objdump_args,
+            ign_branch_targets=options.ign_branch_targets,
         )
         c_source = preprocess(base_c)
 
@@ -778,6 +781,20 @@ def main() -> None:
         metavar="[1-100]",
         default=100,
     )
+    if DEFAULT_IGN_BRANCH_TARGETS:
+        parser.add_argument(
+            "--no-ignore-branch-targets",
+            dest="ign_branch_targets",
+            action="store_false",
+            help="Do not ignore branch targets in objdump output",
+        )
+    else:
+        parser.add_argument(
+            "--ignore-branch-targets",
+            dest="ign_branch_targets",
+            action="store_true",
+            help="Ignore branch targets in objdump output",
+        )
 
     args = parser.parse_args()
 
@@ -807,6 +824,7 @@ def main() -> None:
         no_context_output=args.no_context_output,
         debug_mode=args.debug_mode,
         speed=args.speed,
+        ign_branch_targets=args.ign_branch_targets,
     )
 
     run(options)

--- a/src/main.py
+++ b/src/main.py
@@ -36,9 +36,6 @@ from .helpers import (
     trim_source,
 )
 
-MIN_PRIO = 0.01
-MAX_PRIO = 2.0
-
 from .permuter import (
     EvalError,
     EvalResult,
@@ -56,6 +53,8 @@ from .profiler import Profiler
 from .randomizer import RANDOMIZATION_PASSES
 from .scorer import Scorer
 
+MIN_PRIO = 0.01
+MAX_PRIO = 2.0
 # The probability that the randomizer continues transforming the output it
 # generated last time.
 DEFAULT_RAND_KEEP_PROB = 0.6
@@ -315,7 +314,7 @@ def run_inner(options: Options, heartbeat: Callable[[], None]) -> List[int]:
         force_seed = 0 if len(seed_parts) == 1 else seed_parts[0]
 
     name_counts: Dict[str, int] = {}
-    for i, d in enumerate(options.directories):
+    for _i, d in enumerate(options.directories):
         heartbeat()
         compile_cmd = os.path.join(d, "compile.sh")
         target_o = os.path.join(d, "target.o")
@@ -433,7 +432,7 @@ def run_inner(options: Options, heartbeat: Callable[[], None]) -> List[int]:
     else:
         seed_iterators: List[Optional[Iterator[int]]] = [
             permuter.seed_iterator()
-            for perm_ind, permuter in enumerate(context.permuters)
+            for _perm_ind, permuter in enumerate(context.permuters)
         ]
         seed_iterators_remaining = len(seed_iterators)
         next_iterator_index = 0
@@ -477,7 +476,7 @@ def run_inner(options: Options, heartbeat: Callable[[], None]) -> List[int]:
 
         # Start local worker threads
         processes: List[multiprocessing.Process] = []
-        for i in range(options.threads):
+        for _i in range(options.threads):
             p = multiprocessing.Process(
                 target=multiprocess_worker,
                 args=(context.permuters, worker_task_queue, feedback_queue),
@@ -545,7 +544,7 @@ def run_inner(options: Options, heartbeat: Callable[[], None]) -> List[int]:
                     found_zero = True
                     if options.stop_on_zero:
                         break
-            elif isinstance(feedback, NeedMoreWork):
+            elif isinstance(feedback, NeedMoreWork):  # pyright: ignore[reportUnnecessaryIsInstance]
                 task = get_task(source)
                 if task is not None:
                     if source == -1:
@@ -556,7 +555,7 @@ def run_inner(options: Options, heartbeat: Callable[[], None]) -> List[int]:
                 static_assert_unreachable(feedback)
 
         # Signal workers to stop.
-        for i in range(active_workers):
+        for _i in range(active_workers):
             worker_task_queue.put(Finished())
 
         for conn in net_conns:
@@ -574,7 +573,7 @@ def run_inner(options: Options, heartbeat: Callable[[], None]) -> List[int]:
                 if not (options.stop_on_zero and found_zero):
                     if process_result(feedback, who):
                         found_zero = True
-            elif isinstance(feedback, NeedMoreWork):
+            elif isinstance(feedback, NeedMoreWork):  # pyright: ignore[reportUnnecessaryIsInstance]
                 pass
             else:
                 static_assert_unreachable(feedback)
@@ -600,7 +599,7 @@ class PrintRandomizationPassesAction(argparse.Action):
         values: object,
         option_string: Optional[str] = None,
     ) -> None:
-        weights = get_default_randomization_weights("base")
+        _weights = get_default_randomization_weights("base")
         for method in RANDOMIZATION_PASSES:
             print(f"{method.__name__}:")
             docs = (method.__doc__ or "").strip()

--- a/src/net/evaluator.py
+++ b/src/net/evaluator.py
@@ -106,7 +106,7 @@ def _create_permuter(data: PermuterData) -> Permuter:
             best_only=False,
             score_threshold=None,
             debug_mode=False,
-            speed=1,
+            speed=100,
         )
     except:
         os.unlink(path)

--- a/src/net/server.py
+++ b/src/net/server.py
@@ -7,7 +7,7 @@ import sys
 import threading
 import time
 import traceback
-from typing import BinaryIO, Dict, Optional, Set, Tuple, Union, TYPE_CHECKING
+from typing import BinaryIO, Dict, Optional, Set, Tuple, Union, Any, cast, TYPE_CHECKING
 import zlib
 
 if TYPE_CHECKING:
@@ -97,7 +97,7 @@ class PermInitSuccess:
 class WorkDone:
     perm_id: str
     id: int
-    obj: dict
+    obj: Dict[Any, Any]
     time_us: int
     compressed_source: Optional[bytes]
 
@@ -165,7 +165,7 @@ class OutputWork:
     handle: int
     time_start: float
     time_us: int
-    obj: dict
+    obj: Dict[Any, Any]
     compressed_source: Optional[bytes]
 
 
@@ -301,7 +301,7 @@ class NetThread:
             client_id = json_prop(msg, "client_id", str)
             client_name = json_prop(msg, "client_name", str)
             client = Client(client_id, client_name)
-            data = json_prop(msg, "data", dict)
+            data = cast(Dict[Any, Any], json_prop(msg, "data", dict))
             compressed_source = self._port.receive()
             compressed_target_o_bin = self._port.receive()
 
@@ -392,7 +392,7 @@ class NetThread:
         elif isinstance(item, OutputNeedMoreWork):
             self._port.send_json({"type": "need_work"})
 
-        elif isinstance(item, OutputWork):
+        elif isinstance(item, OutputWork):  # pyright: ignore[reportUnnecessaryIsInstance]
             overhead_us = int((time.time() - item.time_start) * 10**6) - item.time_us
             self._port.send_json(
                 {
@@ -602,7 +602,7 @@ class ServerInner:
         elif isinstance(msg, NeedMoreWork):
             self._need_work()
 
-        elif isinstance(msg, NetThreadDisconnected):
+        elif isinstance(msg, NetThreadDisconnected):  # pyright: ignore[reportUnnecessaryIsInstance]
             self._send_io_global(IoServerFailed(msg.graceful, msg.message))
 
         else:
@@ -651,7 +651,7 @@ class ServerInner:
 
             elif msg_type == "result":
                 compressed_source: Optional[bytes] = None
-                if msg.get("has_source") == True:
+                if msg.get("has_source") is True:
                     compressed_source = self._evaluator_port.receive()
                 perm_id = json_prop(msg, "permuter", str)
                 id = json_prop(msg, "id", int)

--- a/src/objdump.py
+++ b/src/objdump.py
@@ -229,7 +229,6 @@ def parse_relocated_line(line: str) -> Tuple[str, str, str]:
 
 
 def pre_process(mnemonic: str, args: str, next_row: Optional[str]) -> Tuple[str, str]:
-
     if next_row and "R_PPC_EMB_SDA21" in next_row:
         # With sda21 relocs, the linker transforms `r0` into `r2`/`r13`, and
         # we may encounter this in either pre-transformed or post-transformed

--- a/src/objdump.py
+++ b/src/objdump.py
@@ -446,10 +446,16 @@ def find_executable(arch_executable: Tuple[str, ...], arch_name: str) -> str:
 
 
 def objdump(
-    o_filename: str, arch: ArchSettings, *, stack_differences: bool = False
+    o_filename: str,
+    arch: ArchSettings,
+    *,
+    stack_differences: bool = False,
+    objdump_path: Optional[str] = None,
+    objdump_args: Optional[List[str]] = None,
 ) -> List[Line]:
-    executable = find_executable(tuple(arch.executable), arch.name)
-    output = subprocess.check_output([executable] + arch.arguments + [o_filename])
+    executable = objdump_path or find_executable(tuple(arch.executable), arch.name)
+    arguments = objdump_args or arch.arguments
+    output = subprocess.check_output([executable] + arguments + [o_filename])
     lines = output.decode("utf-8").splitlines()
     return simplify_objdump(lines, arch, stack_differences=stack_differences)
 

--- a/src/perm/perm.py
+++ b/src/perm/perm.py
@@ -70,7 +70,7 @@ class Perm:
 
 
 def _eval_all(seed: int, perms: List[Perm], state: EvalState) -> List[str]:
-    ret = []
+    ret: List[str] = []
     for p in perms:
         seed, sub_seed = divmod(seed, p.perm_count)
         ret.append(p.evaluate(sub_seed, state))
@@ -99,7 +99,7 @@ def _count_either(perms: List[Perm]) -> int:
 
 def _shuffle(items: List[T], seed: int) -> List[T]:
     items = items[:]
-    output = []
+    output: List[T] = []
     while items:
         ind = seed % len(items)
         seed //= len(items)
@@ -289,7 +289,7 @@ class LineSwapAstPerm(Perm):
         return state.gen_ast_statement_perm(self, variation, statements=texts)
 
     def eval_statement_ast(self, args: List[Statement], seed: int) -> List[Statement]:
-        ret = []
+        ret: List[Statement] = []
         for item in _shuffle(args, seed):
             assert isinstance(item, ca.Compound)
             ret.extend(item.block_items or [])

--- a/src/permuter.py
+++ b/src/permuter.py
@@ -4,7 +4,6 @@ import hashlib
 import itertools
 import random
 import re
-import time
 import traceback
 from typing import (
     Dict,

--- a/src/randomizer.py
+++ b/src/randomizer.py
@@ -142,7 +142,7 @@ class Region:
 
 
 def reverse_start_indices(indices: Indices) -> Dict[int, ca.Node]:
-    ret = {}
+    ret: Dict[int, ca.Node] = {}
     for k, v in indices.starts.items():
         ret[v] = k
     return ret
@@ -195,9 +195,9 @@ def compute_write_locations(
         if var_name not in writes:
             writes[var_name] = []
         else:
-            assert (
-                loc > writes[var_name][-1]
-            ), "consistent traversal order should guarantee monotonicity here"
+            assert loc > writes[var_name][-1], (
+                "consistent traversal order should guarantee monotonicity here"
+            )
         writes[var_name].append(loc)
 
     class Visitor(ca.NodeVisitor):
@@ -228,9 +228,9 @@ def compute_read_locations(top_node: ca.Node, indices: Indices) -> Dict[str, Lis
         if var_name not in reads:
             reads[var_name] = []
         else:
-            assert (
-                loc > reads[var_name][-1]
-            ), "consistent traversal order should guarantee monotonicity here"
+            assert loc > reads[var_name][-1], (
+                "consistent traversal order should guarantee monotonicity here"
+            )
         reads[var_name].append(loc)
     return reads
 
@@ -404,19 +404,19 @@ def random_bool(random: Random, prob: float) -> bool:
 
 def random_weighted(random: Random, values: Sequence[Tuple[T, float]]) -> T:
     sumprob = 0.0
-    for (val, prob) in values:
+    for val, prob in values:
         assert prob >= 0, "Probabilities must be non-negative"
         sumprob += prob
     assert sumprob > 0, "Cannot pick randomly from empty set"
     targetprob = random.uniform(0, sumprob)
     sumprob = 0.0
-    for (val, prob) in values:
+    for val, prob in values:
         sumprob += prob
         if sumprob > targetprob:
             return val
 
     # Float imprecision
-    for (val, prob) in values:
+    for val, prob in values:
         if prob > 0:
             return val
     assert False, "unreachable"
@@ -544,10 +544,10 @@ def maybe_reuse_var(
     if not same_type(var_type, type, typemap, allow_similar=True):
         return None
 
-    def find_next(list: List[int], value: int) -> Optional[int]:
-        ind = bisect.bisect_left(list, value)
-        if ind < len(list):
-            return list[ind]
+    def find_next(lst: List[int], value: int) -> Optional[int]:
+        ind = bisect.bisect_left(lst, value)
+        if ind < len(lst):
+            return lst[ind]
         return None
 
     assignment_ind = indices.starts[assign_before]
@@ -983,9 +983,9 @@ def perm_randomize_function_type(
             new_decl = copy.copy(item)
             all_decls.append((new_decl, i, new_decl))
         if isinstance(item, ca.FuncDef) and item.decl.name == name:
-            assert isinstance(
-                item.decl.type, ca.FuncDecl
-            ), "function definitions have function types"
+            assert isinstance(item.decl.type, ca.FuncDecl), (
+                "function definitions have function types"
+            )
             new_fndef = copy.copy(item)
             new_decl = copy.copy(item.decl)
             new_fndef.decl = new_decl
@@ -1995,6 +1995,7 @@ def perm_split_assignment(
     """Split assignments of the form `a = b . c . d ...;` into
     `a = b; a = a . c . d ...;` or `a = c . d ...; a = b . a;` or similar."""
     cands = []
+
     # Look for assignments of the form 'var = binaryOp' (ignores op=)
     class Visitor(ca.NodeVisitor):
         def visit_Assignment(self, node: ca.Assignment) -> None:

--- a/src/scorer.py
+++ b/src/scorer.py
@@ -23,12 +23,16 @@ class Scorer:
         stack_differences: bool,
         algorithm: str,
         debug_mode: bool,
+        objdump_path: Optional[str] = None,
+        objdump_args: Optional[List[str]] = None,
     ):
         self.target_o = target_o
         self.arch = get_arch(target_o)
         self.stack_differences = stack_differences
         self.algorithm = algorithm
         self.debug_mode = debug_mode
+        self.objdump_path = objdump_path
+        self.objdump_args = objdump_args
         _, self.target_seq = self._objdump(target_o)
         self.difflib_differ: difflib.SequenceMatcher[str] = difflib.SequenceMatcher(
             autojunk=False
@@ -36,7 +40,13 @@ class Scorer:
         self.difflib_differ.set_seq2([line.mnemonic for line in self.target_seq])
 
     def _objdump(self, o_file: str) -> Tuple[str, List[Line]]:
-        lines = objdump(o_file, self.arch, stack_differences=self.stack_differences)
+        lines = objdump(
+            o_file,
+            self.arch,
+            stack_differences=self.stack_differences,
+            objdump_path=self.objdump_path,
+            objdump_args=self.objdump_args,
+        )
         return "\n".join([line.row for line in lines]), lines
 
     def score(self, cand_o: Optional[str]) -> Tuple[int, str]:

--- a/src/scorer.py
+++ b/src/scorer.py
@@ -45,13 +45,13 @@ class Scorer:
 
         objdump_output, cand_seq = self._objdump(cand_o)
 
-        num_stack_penalties = 0
-        num_regalloc_penalties = 0
-        num_reordering_penalties = 0
-        num_insertion_penalties = 0
-        num_deletion_penalties = 0
-        deletions = []
-        insertions = []
+        num_stack_penalties: int = 0
+        num_regalloc_penalties: int = 0
+        num_reordering_penalties: int = 0
+        num_insertion_penalties: int = 0
+        num_deletion_penalties: int = 0
+        deletions: List[str] = []
+        insertions: List[str] = []
 
         def field_matches_any_symbol(field: str, arch: ArchSettings) -> bool:
             if arch.name == "ppc":
@@ -105,7 +105,8 @@ class Scorer:
             else:
                 # If the last field has a parenthesis suffix, e.g. "0x38(r7)"
                 # we split that part out to make it a separate field
-                # however, we don't split if it has a proceeding %hi/%lo  e.g."%lo(.data)" or "%hi(.rodata + 0x10)"
+                # however, we don't split if it has a proceeding %hi/%lo
+                # e.g."%lo(.data)" or "%hi(.rodata + 0x10)"
                 re_paren = re.compile(r"(?<!%hi)(?<!%lo)\(")
                 oldfields = oldfields[:-1] + (
                     re_paren.split(oldfields[-1]) if len(oldfields) > 0 else []
@@ -157,7 +158,7 @@ class Scorer:
             self.difflib_differ.set_seq1([line.mnemonic for line in cand_seq])
             result_diff = self.difflib_differ.get_opcodes()
 
-        for (tag, i1, i2, j1, j2) in result_diff:
+        for tag, i1, i2, j1, j2 in result_diff:
             if tag == "equal":
                 for k in range(i2 - i1):
                     old_line = self.target_seq[j1 + k]
@@ -172,7 +173,7 @@ class Scorer:
 
         if self.debug_mode:
             # Print simple asm diff
-            for (tag, i1, i2, j1, j2) in result_diff:
+            for tag, i1, i2, j1, j2 in result_diff:
                 if tag == "equal":
                     for k in range(i2 - i1):
                         old = self.target_seq[j1 + k].row

--- a/src/scorer.py
+++ b/src/scorer.py
@@ -4,7 +4,7 @@ import re
 from typing import Dict, List, Optional, Sequence, Tuple
 from collections import Counter
 
-from .objdump import ArchSettings, Line, objdump, get_arch
+from .objdump import ArchSettings, Line, objdump, get_arch, DEFAULT_IGN_BRANCH_TARGETS
 
 
 class Scorer:
@@ -25,6 +25,7 @@ class Scorer:
         debug_mode: bool,
         objdump_path: Optional[str] = None,
         objdump_args: Optional[List[str]] = None,
+        ign_branch_targets: bool = DEFAULT_IGN_BRANCH_TARGETS,
     ):
         self.target_o = target_o
         self.arch = get_arch(target_o)
@@ -33,6 +34,7 @@ class Scorer:
         self.debug_mode = debug_mode
         self.objdump_path = objdump_path
         self.objdump_args = objdump_args
+        self.ign_branch_targets = ign_branch_targets
         _, self.target_seq = self._objdump(target_o)
         self.difflib_differ: difflib.SequenceMatcher[str] = difflib.SequenceMatcher(
             autojunk=False
@@ -46,6 +48,7 @@ class Scorer:
             stack_differences=self.stack_differences,
             objdump_path=self.objdump_path,
             objdump_args=self.objdump_args,
+            ign_branch_targets=self.ign_branch_targets,
         )
         return "\n".join([line.row for line in lines]), lines
 


### PR DESCRIPTION
This PR introduces the following changes:

## FIXES
- Escaped `%` in the help string to prevent argparse help message generation from breaking.
- Set speed value to 100 when creating permuter instance in evaluator.py
  (parameter was not added after the signature was changed when the speed parameter was introduced)

## FEATURES
- Added support for specifying a custom `objdump` executable path and custom command-line options.  
  (These settings can be configured in `permuter_settings.toml` and `settings.toml`. When importing settings, they are automatically transferred to `settings.toml`)
- Added a command-line option to disable ignoring branch targets.  
  (The `ign_branch_targets` variable has been replaced with a `DEFAULT_IGN_BRANCH_TARGETS` constant, which serves as both a default function parameter and the basis for generating the command-line argument:  
  - `--no-ignore-branch-targets` if `DEFAULT_IGN_BRANCH_TARGETS` is `TRUE`  
  - `--ignore-branch-targets` if `FALSE`)
- Improved assembly formatting in debug mode by ensuring proper alignment.  
  (Instead of relying on tabs for formatting—potentially causing misaligned columns—the code now calculates the maximum mnemonic length and aligns all mnemonics accordingly. The 40-character column limit for target assembly remains unchanged.)
- Removed color highlighting for lines where the new field matches a symbol but the old field contained a relocation.  
  (For example, `ld a0,%lo(D_0034CFF0)(v0)` <-> `ld a0,%lo(.rodata)(v0)`. These cases are not internally counted as differences, and decomp.me does not color these diffs either, making this behavior more consistent.)

## CHORES
- Improved type hinting to comply with stricter type checkers (e.g., Pyright in strict mode).  
  (For type annotations of basic types such as tuples, lists, and dictionaries, the corresponding types from the `typing` module are now used instead of built-in types to maintain backward compatibility with older Python versions.)
- Added common virtualenv paths to `.gitignore`
  (`/.venv/` and `/venv/`)