### PR TITLE
Add settings flag to specify decomp.me compiler flags

### DIFF
--- a/import.py
+++ b/import.py
@@ -728,7 +728,12 @@ def finalize_compile_command(cmdline: List[str]) -> str:
     return " ".join(quoted[:ind] + ['"$INPUT"'] + quoted[ind:] + ["-o", '"$OUTPUT"'])
 
 
-def get_compiler_flags(cmdline: List[str]) -> str:
+def get_compiler_flags(settings: Mapping[str, object], cmdline: List[str]) -> str:
+    decompme_settings = json_dict(settings, "decompme")
+    flags = decompme_settings.get("flags")
+    if flags:
+        assert isinstance(flags, str)
+        return flags
     flags = [b for a, b in zip(cmdline, cmdline[1:]) if a != "|" and b != "|"]
     return " ".join(shlex.quote(flag) for flag in flags)
 
@@ -962,7 +967,7 @@ def main(arg_list: List[str]) -> None:
                     "context": context,
                     "source_code": source,
                     "compiler": compiler_name,
-                    "compiler_flags": settings["decompme"]["flags"] or get_compiler_flags(compiler),
+                    "compiler_flags": get_compiler_flags(settings, compiler),
                     "diff_label": func_name,
                 }
             ).encode("ascii")

--- a/import.py
+++ b/import.py
@@ -962,7 +962,7 @@ def main(arg_list: List[str]) -> None:
                     "context": context,
                     "source_code": source,
                     "compiler": compiler_name,
-                    "compiler_flags": get_compiler_flags(compiler),
+                    "compiler_flags": settings["decompme"]["flags"] or get_compiler_flags(compiler),
                     "diff_label": func_name,
                 }
             ).encode("ascii")


### PR DESCRIPTION
decomp-permuter can extract compiler flags that aren't necessary or even valid on decomp.me, so the flags should be overridable.