### PR TITLE
Update labels for better support with latest splat/spimdisasm

### DIFF
--- a/prelude.inc
+++ b/prelude.inc
@@ -1,22 +1,50 @@
 .set noat
 .set noreorder
 .set gp=64
-.macro glabel label
-    .global \label
+
+.macro glabel label, visibility=global
+    .\visibility \label
     .type \label, @function
     \label:
 .endm
 
-.macro dlabel label
-    .global \label
-    \label:
-.endm
-
-.macro jlabel label
-    \label:
-.endm
-
 .macro endlabel label
+    .size \label, . - \label
+.endm
+
+.macro alabel label, visibility=global
+    .\visibility \label
+    .type \label, @function
+    \label:
+.endm
+
+.macro ehlabel label, visibility=global
+    .\visibility \label
+    \label:
+.endm
+
+
+.macro jlabel label, visibility=local
+    \label:
+.endm
+
+
+.macro dlabel label, visibility=global
+    .\visibility \label
+    .type \label, @object
+    \label:
+.endm
+
+.macro enddlabel label
+    .size \label, . - \label
+.endm
+
+
+.macro nonmatching label, size=1
+    .global \label\().NON_MATCHING
+    .type \label\().NON_MATCHING, @object
+    .size \label\().NON_MATCHING, \size
+    \label\().NON_MATCHING:
 .endm
 
 # Float register aliases (o32 ABI)


### PR DESCRIPTION
splat/spimdisasm added new labels on the generated assembly and changed a few defaults too (https://github.com/ethteck/splat/pull/466), breaking importing assembly to decomp-permuter.

This PR updates the labels and adds new ones to the prelude.inc file, fixing the import issue.
