### PR TITLE
Strip all dependency generation flags on import

### DIFF
--- a/import.py
+++ b/import.py
@@ -258,8 +258,10 @@ def fixup_build_command(
         if skip_count > 0:
             skip_count -= 1
             continue
-        if part in ["-MF", "-o"]:
+        if part in ["-MF", "-MT", "-MQ", "-o"]:
             skip_count = 1
+            continue
+        if part in ["-M", "-MM", "-MG", "-MP", "-MD", "-MMD", "-Mno-modules"]:
             continue
         if part == ignore_part:
             continue


### PR DESCRIPTION
Currently only the `-MF` dependency generation flag is skipped by the permuter, and some of the other flags need to be `ifdef`ed out in the Makefile when `PERMUTER` is reading it, otherwise the working directory is spammed with generated dependency files. 

Since none of the dependency generation flags are useful if dependencies are not going to be generated and used, they might as well all be stripped which is what this PR does.