### PR TITLE
Don't raise on bare-hex relocated immediates (MIPS jump targets)

### DIFF
--- a/src/objdump.py
+++ b/src/objdump.py
@@ -345,6 +345,39 @@ def pre_process(mnemonic: str, args: str, next_row: Optional[str]) -> Tuple[str,
     return mnemonic, args
 
 
+def imm_is_positive(imm: str) -> bool:
+    """Whether a relocated immediate is positive, for deciding on a '+'.
+
+    objdump prints jump and branch targets as BARE hex, e.g.
+
+        18:	08000047 	j	11c <func+0x11c>
+                18: R_MIPS_26	.text
+
+    which int(imm, 0) rejects ("invalid literal for int() with base 0:
+    '11c'"). The exception propagates out of the Scorer, main.py catches it
+    in try_eval_candidate, and the candidate is silently discarded — the
+    compile is paid for and nothing is reported. On one MIPS/IDO project it
+    cost 4.45% of all candidates (3927 of 88205 compiles), and it makes the
+    BASE unscoreable for any function containing such a jump, which is a
+    CandidateConstructionFailure that aborts the run outright: 3 of 16
+    functions in that sample could not be permuted at all.
+
+    Try base 0 first so decimal and 0x-prefixed immediates keep their exact
+    current meaning, then base 16 for the bare-hex case, and fall back to
+    the sign character for anything neither can parse — the value is only
+    used to choose '+', and a shape we cannot parse must not take the whole
+    candidate down with it.
+    """
+    try:
+        return int(imm, 0) > 0
+    except ValueError:
+        pass
+    try:
+        return int(imm, 16) > 0
+    except ValueError:
+        return not imm.startswith("-")
+
+
 def process_mips_reloc(reloc_row: str, prev: str, repl: str, imm: str) -> str:
     if "R_MIPS_JALR" in reloc_row or "R_MIPS_NONE" in reloc_row:
         return repl
@@ -354,7 +387,7 @@ def process_mips_reloc(reloc_row: str, prev: str, repl: str, imm: str) -> str:
     # here to avoid a crash, by pretending that lost imms are zero for
     # relocations.
     if imm != "0" and imm != "imm" and imm != "addr":
-        repl += "+" + imm if int(imm, 0) > 0 else imm
+        repl += "+" + imm if imm_is_positive(imm) else imm
     if any(
         reloc in reloc_row
         for reloc in ["R_MIPS_LO16", "R_MIPS_LITERAL", "R_MIPS_GPREL16"]

--- a/test/test_objdump.py
+++ b/test/test_objdump.py
@@ -1,0 +1,53 @@
+import unittest
+
+from src.objdump import imm_is_positive, process_mips_reloc
+
+
+class TestMipsReloc(unittest.TestCase):
+    def test_bare_hex_jump_target(self) -> None:
+        """objdump prints jump/branch targets as bare hex.
+
+        The row that used to raise, from a real IDO/MIPS object:
+
+            18:	08000047 	j	11c <func_80096928+0x11c>
+                    18: R_MIPS_26	.text
+        """
+        self.assertTrue(imm_is_positive("11c"))
+        self.assertEqual(
+            process_mips_reloc("18: R_MIPS_26\t.text", "j\t11c", ".text", "11c"),
+            ".text+11c",
+        )
+
+    def test_decimal_and_hex_immediates_are_unchanged(self) -> None:
+        for imm in ["4", "108", "0x4", "0x6c"]:
+            self.assertTrue(imm_is_positive(imm), imm)
+        self.assertEqual(
+            process_mips_reloc(
+                "74: R_MIPS_LO16\t.rodata", "lw\tv0,4", ".rodata", "4"
+            ),
+            "%lo(.rodata+4)",
+        )
+
+    def test_negative_immediates_keep_their_sign(self) -> None:
+        for imm in ["-4", "-0x4", "-11c"]:
+            self.assertFalse(imm_is_positive(imm), imm)
+        self.assertEqual(
+            process_mips_reloc(
+                "74: R_MIPS_LO16\t.rodata", "lw\tv0,-4", ".rodata", "-4"
+            ),
+            "%lo(.rodata-4)",
+        )
+
+    def test_zero_is_positive_for_neither_base(self) -> None:
+        for imm in ["0x0", "00", "0"]:
+            self.assertFalse(imm_is_positive(imm), imm)
+
+    def test_unparseable_immediate_does_not_raise(self) -> None:
+        # Whatever else objdump may print, a shape we cannot parse must not
+        # take the whole candidate down with it.
+        self.assertTrue(imm_is_positive("<target>"))
+        self.assertFalse(imm_is_positive("-<target>"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`process_mips_reloc` raises on immediates that objdump prints as bare hex, which on MIPS is how jump and branch targets are printed:

```
  18:	08000047 	j	11c <func_80096928+0x11c>
			18: R_MIPS_26	.text
```

`parse_relocated_line` hands `imm = "11c"` to `process_mips_reloc`, which evaluates `int(imm, 0)` and gets `ValueError: invalid literal for int() with base 0: '11c'`.

### Why it is worth fixing rather than rare

The exception escapes `Scorer.score()`, and what happens next depends on where it lands:

* **For a candidate**, `main.py` catches it in `try_eval_candidate` and the candidate becomes an `EvalError`. The compile has already been paid for, the candidate is discarded, and with `--show-errors` off nothing is printed — so the loss is invisible.
* **For the base**, it surfaces as `CandidateConstructionFailure` and the run aborts, so any function containing such a jump cannot be permuted at all.

I hit this while A/B-testing the search loop on an N64 project (GCC 2.7.2, IDO-era code), which gave me exact numbers over 78 runs and 88,205 compiles:

* **3,927 candidates lost — 4.45% of all compiles.**
* **3 of the 16 selected functions could not be permuted**, because their base hit it.

The three bases score fine with the patch (339, 110, 251).

### The fix

`int(imm, 0)` is only used to decide whether to write a `+`, so it does not need to be strict. `imm_is_positive` tries base 0 first — decimal and `0x`-prefixed immediates keep exactly their current meaning — then base 16 for the bare-hex case, then falls back to the sign character, on the principle that a shape neither base can parse should not take the whole candidate down with it.

### Tests

Adds `test/test_objdump.py` (5 tests): the bare-hex jump target from the object above, decimal and `0x` immediates unchanged, negatives keeping their sign, zero, and an unparseable immediate not raising.

Note for reviewing: `python3 -m unittest discover -s test/` reports 16 failures both before and after this change on my machine — they are in `test_perm.py` and need a working compiler via `test/compile.sh`, which I don't have set up. The 5 new tests pass, and no previously-passing test changes state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
